### PR TITLE
docs: add OpenAPI documentation for OIDC endpoints

### DIFF
--- a/src/api/security/openApi.json
+++ b/src/api/security/openApi.json
@@ -25,6 +25,10 @@
     {
       "name": "access",
       "description": "Device access"
+    },
+    {
+      "name": "oidc",
+      "description": "OpenID Connect (OIDC) configuration"
     }
   ],
   "components": {
@@ -37,6 +41,176 @@
       "RequestState": {
         "type": "string",
         "enum": ["PENDING", "FAILED", "COMPLETED"]
+      },
+      "OIDCPermission": {
+        "type": "string",
+        "enum": ["readonly", "readwrite", "admin"],
+        "description": "Signal K permission level"
+      },
+      "OIDCConfigResponse": {
+        "type": "object",
+        "description": "OIDC configuration (secrets redacted)",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether OIDC authentication is enabled"
+          },
+          "issuer": {
+            "type": "string",
+            "description": "OIDC provider issuer URL",
+            "example": "https://auth.example.com"
+          },
+          "clientId": {
+            "type": "string",
+            "description": "OAuth client ID"
+          },
+          "clientSecret": {
+            "type": "string",
+            "description": "Always empty (redacted for security)"
+          },
+          "clientSecretSet": {
+            "type": "boolean",
+            "description": "Whether a client secret has been configured"
+          },
+          "redirectUri": {
+            "type": "string",
+            "description": "OAuth redirect URI (optional, auto-generated if not set)"
+          },
+          "scope": {
+            "type": "string",
+            "description": "OAuth scopes to request",
+            "example": "openid email profile"
+          },
+          "defaultPermission": {
+            "$ref": "#/components/schemas/OIDCPermission"
+          },
+          "autoCreateUsers": {
+            "type": "boolean",
+            "description": "Automatically create users on first OIDC login"
+          },
+          "adminGroups": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Groups that grant admin permission",
+            "example": ["admins", "sk-admin"]
+          },
+          "readwriteGroups": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Groups that grant read/write permission",
+            "example": ["users", "operators"]
+          },
+          "groupsAttribute": {
+            "type": "string",
+            "description": "ID token claim containing user groups",
+            "example": "groups"
+          },
+          "providerName": {
+            "type": "string",
+            "description": "Display name shown on login button",
+            "example": "SSO Login"
+          },
+          "autoLogin": {
+            "type": "boolean",
+            "description": "Automatically redirect to OIDC provider when not authenticated"
+          },
+          "envOverrides": {
+            "type": "object",
+            "description": "Fields that are overridden by environment variables",
+            "additionalProperties": { "type": "boolean" }
+          }
+        }
+      },
+      "OIDCConfigRequest": {
+        "type": "object",
+        "description": "OIDC configuration update request",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "issuer": {
+            "type": "string",
+            "example": "https://auth.example.com"
+          },
+          "clientId": {
+            "type": "string"
+          },
+          "clientSecret": {
+            "type": "string",
+            "description": "Leave empty to keep existing secret"
+          },
+          "scope": {
+            "type": "string",
+            "example": "openid email profile"
+          },
+          "defaultPermission": {
+            "$ref": "#/components/schemas/OIDCPermission"
+          },
+          "autoCreateUsers": {
+            "type": "boolean"
+          },
+          "adminGroups": {
+            "oneOf": [
+              { "type": "string", "description": "Comma-separated list" },
+              { "type": "array", "items": { "type": "string" } }
+            ]
+          },
+          "readwriteGroups": {
+            "oneOf": [
+              { "type": "string", "description": "Comma-separated list" },
+              { "type": "array", "items": { "type": "string" } }
+            ]
+          },
+          "groupsAttribute": {
+            "type": "string"
+          },
+          "providerName": {
+            "type": "string"
+          },
+          "autoLogin": {
+            "type": "boolean"
+          }
+        }
+      },
+      "OIDCTestRequest": {
+        "type": "object",
+        "required": ["issuer"],
+        "properties": {
+          "issuer": {
+            "type": "string",
+            "description": "OIDC provider issuer URL to test",
+            "example": "https://auth.example.com"
+          }
+        }
+      },
+      "OIDCTestResponse": {
+        "type": "object",
+        "description": "OIDC connection test result",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "issuer": {
+            "type": "string",
+            "description": "Issuer from discovery document"
+          },
+          "authorization_endpoint": {
+            "type": "string",
+            "description": "OAuth authorization endpoint"
+          },
+          "token_endpoint": {
+            "type": "string",
+            "description": "OAuth token endpoint"
+          },
+          "userinfo_endpoint": {
+            "type": "string",
+            "description": "OIDC userinfo endpoint"
+          },
+          "jwks_uri": {
+            "type": "string",
+            "description": "JSON Web Key Set URI"
+          }
+        }
       }
     },
     "responses": {
@@ -307,6 +481,171 @@
           },
           "default": {
             "$ref": "#/components/responses/ErrorResponse"
+          }
+        }
+      }
+    },
+    "/security/oidc": {
+      "get": {
+        "tags": ["oidc"],
+        "summary": "Get OIDC configuration.",
+        "description": "Returns the current OIDC configuration with secrets redacted. Includes indicators for fields overridden by environment variables.",
+        "security": [{ "cookieAuth": [] }, { "bearerAuth": [] }],
+        "responses": {
+          "200": {
+            "description": "OIDC configuration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OIDCConfigResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - admin access required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "example": "Security config not allowed"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": ["oidc"],
+        "summary": "Update OIDC configuration.",
+        "description": "Updates the OIDC configuration. Fields set via environment variables cannot be overridden. Leave clientSecret empty to preserve the existing secret.",
+        "security": [{ "cookieAuth": [] }, { "bearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OIDCConfigRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Configuration saved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "OIDC configuration saved"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid configuration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid issuer URL"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - admin access required"
+          },
+          "500": {
+            "description": "Failed to save configuration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "Unable to save OIDC configuration"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/security/oidc/test": {
+      "post": {
+        "tags": ["oidc"],
+        "summary": "Test OIDC connection.",
+        "description": "Tests connectivity to an OIDC provider by fetching its discovery document. Returns the provider's endpoints if successful.",
+        "security": [{ "cookieAuth": [] }, { "bearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OIDCTestRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Connection successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OIDCTestResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "Issuer URL is required"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - admin access required"
+          },
+          "502": {
+            "description": "Failed to connect to OIDC provider",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "Failed to fetch OIDC discovery document"
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary

- Add OpenAPI 3.0 documentation for the OIDC configuration endpoints
- New schemas: `OIDCConfigResponse`, `OIDCConfigRequest`, `OIDCTestRequest`, `OIDCTestResponse`, `OIDCPermission`
- Documented endpoints:
  - `GET /security/oidc` - Retrieve OIDC configuration (secrets redacted)
  - `PUT /security/oidc` - Update OIDC configuration
  - `POST /security/oidc/test` - Test OIDC provider connectivity

This completes the Phase 4 (Admin UI Configuration) by adding the missing API documentation.

## Test plan

- [x] JSON syntax validates correctly
- [x] TypeScript build passes

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)