### PR TITLE
use <i> with fa style instead of Spinner

### DIFF
--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -163,6 +163,20 @@ The OIDC module provides OpenID Connect authentication for Single Sign-On.
 8. Server creates/updates local user record
 9. Server issues local JWT session
 
+### Logout Flow (RP-Initiated)
+
+The `/signalk/v1/auth/oidc/logout` endpoint supports OpenID Connect RP-Initiated
+Logout:
+
+1. User clicks "Logout"
+2. Server clears local session cookies
+3. If provider supports `end_session_endpoint`:
+   - Redirects to provider's logout endpoint with `post_logout_redirect_uri`
+   - Provider logs out the user and redirects back
+4. If provider doesn't support logout, redirects locally
+
+This ensures users are logged out of both Signal K and the identity provider.
+
 ### Dependency Injection
 
 `oidc-auth.ts` receives dependencies from tokensecurity via the

--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -1,0 +1,235 @@
+---
+title: Security Architecture
+---
+
+# Security Architecture
+
+This document describes the architecture of Signal K Server's security system,
+including how the various components interact.
+
+## Overview
+
+Signal K Server uses a pluggable security strategy pattern. The security system
+consists of:
+
+1. **Security Strategy Interface** (`src/security.ts`) - Defines the contract
+   for security implementations
+2. **Dummy Security** (`src/dummysecurity.ts`) - No-op implementation when
+   security is disabled
+3. **Token Security** (`src/tokensecurity.js`) - Full implementation with JWT-
+   based authentication
+4. **OIDC Module** (`src/oidc/`) - OpenID Connect authentication support
+
+## Component Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        Signal K Server                          │
+│                                                                 │
+│  ┌─────────────────────┐       ┌─────────────────────────────┐ │
+│  │    security.ts      │       │     tokensecurity.js        │ │
+│  │                     │       │                             │ │
+│  │ - SecurityStrategy  │◄──────│ - login/logout routes       │ │
+│  │   interface         │       │ - JWT token management      │ │
+│  │ - startSecurity()   │       │ - Session cookie management │ │
+│  │ - saveSecurityConfig│       │ - User/device management    │ │
+│  └─────────────────────┘       │ - ACL enforcement           │ │
+│           ▲                    └──────────────┬──────────────┘ │
+│           │                                   │                │
+│           │                                   │ Dependencies   │
+│  ┌────────┴────────┐                         ▼                │
+│  │ dummysecurity.ts │           ┌─────────────────────────────┐ │
+│  │                  │           │       src/oidc/             │ │
+│  │ - No-op impl     │           │                             │ │
+│  │ - Used when      │           │ ┌─────────────────────────┐ │ │
+│  │   security       │           │ │     oidc-auth.ts        │ │ │
+│  │   disabled       │           │ │                         │ │ │
+│  └──────────────────┘           │ │ - registerOIDCRoutes()  │ │ │
+│                                 │ │ - findOrCreateOIDCUser()│ │ │
+│                                 │ └────────────┬────────────┘ │ │
+│                                 │              │uses          │ │
+│                                 │ ┌────────────┴────────────┐ │ │
+│                                 │ │ Helper Modules          │ │ │
+│                                 │ │ - config.ts             │ │ │
+│                                 │ │ - state.ts              │ │ │
+│                                 │ │ - pkce.ts               │ │ │
+│                                 │ │ - discovery.ts          │ │ │
+│                                 │ │ - authorization.ts      │ │ │
+│                                 │ │ - token-exchange.ts     │ │ │
+│                                 │ │ - id-token-validation.ts│ │ │
+│                                 │ └─────────────────────────┘ │ │
+│                                 └─────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Security Strategy Interface
+
+The `SecurityStrategy` interface (`src/security.ts`) defines the methods that
+a security implementation must provide:
+
+### Core Methods
+
+- `isDummy()`: Returns true for dummy implementation
+- `allowReadOnly()`: Whether anonymous read access is allowed
+- `getConfiguration()`: Returns the security configuration
+
+### Authentication Methods
+
+- `getLoginStatus()`: Current authentication status
+- `generateToken()`: Create a JWT for authenticated access
+
+### Authorization Methods
+
+- `allowRestart()`: Can the user restart the server?
+- `allowConfigure()`: Can the user modify configuration?
+- `shouldAllowWrite()`: Check write permission for deltas
+- `shouldAllowPut()`: Check PUT permission
+
+### User Management
+
+- `getUsers()`: List all users
+- `addUser()`: Create a new user
+- `updateUser()`: Modify user properties
+- `deleteUser()`: Remove a user
+- `setPassword()`: Change user password
+
+### Device Management
+
+- `getDevices()`: List registered devices
+- `updateDevice()`: Modify device properties
+- `deleteDevice()`: Remove a device
+
+### Access Control
+
+- `filterReadDelta()`: Filter delta data based on ACLs
+- `shouldFilterDeltas()`: Whether ACL filtering is active
+
+## Token Security Implementation
+
+`tokensecurity.js` is the production security implementation. It provides:
+
+### Authentication Flow
+
+1. **Local Login**: Username/password via `/login` or `/signalk/v1/auth/login`
+2. **OIDC Login**: Delegates to `oidc-auth.ts` for SSO authentication
+3. **Device Access Requests**: Devices can request access tokens
+
+### Session Management
+
+Sessions are managed via HTTP-only cookies:
+
+- `JAUTHENTICATION`: The JWT token
+- `skLoginInfo`: Login status for JavaScript access (non-httpOnly)
+
+Session cookie helpers ensure consistent security settings:
+
+- `httpOnly: true` (for JAUTHENTICATION)
+- `sameSite: 'strict'`
+- `secure: true` (when over HTTPS)
+
+### Token Format
+
+JWTs contain:
+
+```json
+{
+  "id": "username",
+  "exp": 1234567890
+}
+```
+
+## OIDC Integration
+
+The OIDC module provides OpenID Connect authentication for Single Sign-On.
+
+### Architecture
+
+```
+┌──────────────┐     ┌───────────────────┐     ┌──────────────────┐
+│   Browser    │────▶│  Signal K Server  │────▶│  OIDC Provider   │
+│              │◀────│                   │◀────│  (Keycloak, etc) │
+└──────────────┘     └───────────────────┘     └──────────────────┘
+```
+
+### Authentication Flow
+
+1. User clicks "SSO Login"
+2. Server creates state, stores in encrypted cookie
+3. Redirects to OIDC provider's authorization endpoint
+4. User authenticates with provider
+5. Provider redirects back with authorization code
+6. Server exchanges code for tokens
+7. Server validates ID token
+8. Server creates/updates local user record
+9. Server issues local JWT session
+
+### Dependency Injection
+
+`oidc-auth.ts` receives dependencies from tokensecurity via the
+`OIDCAuthDependencies` interface:
+
+```typescript
+interface OIDCAuthDependencies {
+  getConfiguration: () => SecurityConfig
+  getOIDCConfig: () => OIDCConfig
+  setSessionCookie: (res, req, token, username, options?) => void
+  clearSessionCookie: (res) => void
+  generateJWT: (userId, expiration?) => string
+  saveConfig: (config, callback) => void
+}
+```
+
+This design:
+
+- Avoids circular dependencies
+- Allows tokensecurity to own session management
+- Keeps OIDC code focused on OIDC-specific logic
+- Makes testing easier through dependency injection
+
+### Helper Modules
+
+Each OIDC helper module has a single responsibility:
+
+| Module                   | Responsibility                 |
+| ------------------------ | ------------------------------ |
+| `config.ts`              | Parse and validate OIDC config |
+| `state.ts`               | Create/encrypt/decrypt state   |
+| `pkce.ts`                | Generate PKCE code verifier    |
+| `discovery.ts`           | Fetch OIDC provider metadata   |
+| `authorization.ts`       | Build authorization URLs       |
+| `token-exchange.ts`      | Exchange code for tokens       |
+| `id-token-validation.ts` | Validate ID token signatures   |
+
+## Configuration
+
+Security configuration is stored in `security.json`:
+
+```json
+{
+  "users": [...],
+  "devices": [...],
+  "secretKey": "...",
+  "expiration": "1h",
+  "allow_readonly": true,
+  "acls": [...],
+  "oidc": {
+    "enabled": true,
+    "issuer": "https://...",
+    "clientId": "...",
+    "clientSecret": "..."
+  }
+}
+```
+
+Environment variables can override configuration values. OIDC secrets are
+recommended to be set via environment variables (`SIGNALK_OIDC_*`).
+
+## Strategy Selection
+
+The security strategy is selected at startup in `startSecurity()`:
+
+1. Check `SECURITYSTRATEGY` environment variable
+2. Check `config.settings.security.strategy` in settings
+3. Fall back to `dummysecurity` if neither is set
+
+The strategy is dynamically loaded and attached to `app.securityStrategy`.

--- a/docs/security.md
+++ b/docs/security.md
@@ -212,3 +212,126 @@ And set `trustProxy` to trust only the nginx server:
 - Only enable `trustProxy` if you are actually running behind a reverse proxy
 - Configure the value to trust only your specific proxy IP address when possible
 - Using `trustProxy: true` trusts all proxies, which could allow IP spoofing if your server is directly accessible
+
+## OpenID Connect (OIDC) Authentication
+
+Signal K Server supports Single Sign-On (SSO) authentication via OpenID Connect. This allows users to authenticate using an external identity provider such as Keycloak, Authelia, Auth0, or any OIDC-compliant service.
+
+### Configuration
+
+OIDC can be configured via environment variables or in `security.json`. Environment variables take precedence and are recommended for secrets.
+
+#### Environment Variables
+
+| Variable                          | Required | Description                                                   |
+| --------------------------------- | -------- | ------------------------------------------------------------- |
+| `SIGNALK_OIDC_ENABLED`            | Yes      | Set to `true` to enable OIDC                                  |
+| `SIGNALK_OIDC_ISSUER`             | Yes      | OIDC provider's issuer URL                                    |
+| `SIGNALK_OIDC_CLIENT_ID`          | Yes      | Client ID registered with the provider                        |
+| `SIGNALK_OIDC_CLIENT_SECRET`      | Yes      | Client secret (keep this secure!)                             |
+| `SIGNALK_OIDC_REDIRECT_URI`       | No       | Override the callback URL                                     |
+| `SIGNALK_OIDC_SCOPE`              | No       | Scopes to request (default: `openid email profile`)           |
+| `SIGNALK_OIDC_DEFAULT_PERMISSION` | No       | Permission for new users: `readonly`, `readwrite`, or `admin` |
+| `SIGNALK_OIDC_AUTO_CREATE_USERS`  | No       | Auto-create users on first login (default: `true`)            |
+
+#### security.json Configuration
+
+```json
+{
+  "oidc": {
+    "enabled": true,
+    "issuer": "https://auth.example.com",
+    "clientId": "signalk",
+    "clientSecret": "your-secret-here",
+    "scope": "openid email profile",
+    "defaultPermission": "readonly",
+    "autoCreateUsers": true
+  }
+}
+```
+
+### OIDC Endpoints
+
+| Endpoint                         | Description                            |
+| -------------------------------- | -------------------------------------- |
+| `/signalk/v1/auth/oidc/login`    | Initiates OIDC login flow              |
+| `/signalk/v1/auth/oidc/callback` | Handles OIDC provider callback         |
+| `/signalk/v1/auth/oidc/logout`   | Logs out of Signal K and OIDC provider |
+| `/signalk/v1/auth/oidc/status`   | Returns OIDC configuration status      |
+
+### Example: Authelia Configuration
+
+[Authelia](https://www.authelia.com/) is a popular open-source authentication server that provides OIDC. Here's how to configure it with Signal K Server.
+
+#### Authelia Configuration
+
+Add a client configuration to your Authelia `configuration.yml`:
+
+```yaml
+identity_providers:
+  oidc:
+    clients:
+      - client_id: signalk
+        client_name: Signal K Server
+        client_secret: '$pbkdf2-sha512$310000$...' # Use authelia hash-password
+        public: false
+        authorization_policy: two_factor # or 'one_factor'
+        redirect_uris:
+          - https://your-signalk-server.local/signalk/v1/auth/oidc/callback
+        scopes:
+          - openid
+          - email
+          - profile
+          - groups
+        userinfo_signed_response_alg: none
+        token_endpoint_auth_method: client_secret_post
+```
+
+Generate the client secret hash using:
+
+```bash
+authelia crypto hash generate pbkdf2 --variant sha512
+```
+
+#### Signal K Configuration
+
+Set these environment variables for Signal K Server:
+
+```bash
+SIGNALK_OIDC_ENABLED=true
+SIGNALK_OIDC_ISSUER=https://auth.your-domain.com
+SIGNALK_OIDC_CLIENT_ID=signalk
+SIGNALK_OIDC_CLIENT_SECRET=your-unhashed-secret
+SIGNALK_OIDC_DEFAULT_PERMISSION=readonly
+```
+
+Or in `docker-compose.yml`:
+
+```yaml
+services:
+  signalk:
+    environment:
+      - SIGNALK_OIDC_ENABLED=true
+      - SIGNALK_OIDC_ISSUER=https://auth.your-domain.com
+      - SIGNALK_OIDC_CLIENT_ID=signalk
+      - SIGNALK_OIDC_CLIENT_SECRET=your-unhashed-secret
+      - SIGNALK_OIDC_DEFAULT_PERMISSION=readonly
+```
+
+#### Post-Logout Redirect
+
+If using Authelia's RP-initiated logout, add Signal K's post-logout URL to Authelia's allowed origins in `configuration.yml`:
+
+```yaml
+identity_providers:
+  oidc:
+    cors:
+      allowed_origins_from_client_redirect_uris: true
+```
+
+### OIDC Security Considerations
+
+1. **Use HTTPS**: OIDC requires secure connections. Always use HTTPS in production.
+2. **Protect secrets**: Store `SIGNALK_OIDC_CLIENT_SECRET` securely, never in version control.
+3. **Restrict permissions**: Set `SIGNALK_OIDC_DEFAULT_PERMISSION=readonly` unless users need write access.
+4. **Disable auto-creation**: In restricted environments, set `SIGNALK_OIDC_AUTO_CREATE_USERS=false` and manually create OIDC users.

--- a/package.json
+++ b/package.json
@@ -121,7 +121,9 @@
     "swagger-ui-express": "^4.5.0",
     "unzipper": "^0.10.10",
     "uuid": "^8.1.0",
-    "ws": "^7.0.0"
+    "ws": "^7.0.0",
+    "jose": "^6.1.0",
+    "openid-client": "^6.1.0"
   },
   "optionalDependencies": {
     "@mxtommy/kip": "^3.2.0",
@@ -167,6 +169,7 @@
     "globals": "^16.0.0",
     "lint-staged": "^10.0.3",
     "mocha": "^11.7.5",
+    "nock": "^13.5.0",
     "prettier": "^3.5.3",
     "rimraf": "^6.0.1",
     "ts-node": "^10.9.1",

--- a/packages/server-admin-ui/src/views/security/Login.js
+++ b/packages/server-admin-ui/src/views/security/Login.js
@@ -22,13 +22,59 @@ import EnableSecurity from './EnableSecurity'
 class Login extends Component {
   constructor(props) {
     super(props)
+    // Check for OIDC error message in URL (from failed callback)
+    // Note: App uses HashRouter, so params are in hash fragment, not query string
+    const urlParams = Login.getHashParams()
+    const oidcErrorMessage = urlParams.has('oidcError')
+      ? urlParams.get('message') || 'SSO login failed'
+      : null
     this.state = {
       loggingIn: false,
-      loginErrorMessage: null
+      loginErrorMessage: oidcErrorMessage
     }
     this.handleInputChange = this.handleInputChange.bind(this)
     this.handleInputKeyUp = this.handleInputKeyUp.bind(this)
     this.handleClick = this.handleClick.bind(this)
+  }
+
+  // Parse URL parameters from hash fragment (for HashRouter)
+  // e.g., "#/login?oidcError=true" → URLSearchParams with oidcError=true
+  static getHashParams() {
+    const hash = window.location.hash
+    const queryIndex = hash.indexOf('?')
+    if (queryIndex === -1) {
+      return new URLSearchParams()
+    }
+    return new URLSearchParams(hash.substring(queryIndex + 1))
+  }
+
+  shouldSkipAutoLogin() {
+    // Check URL params to prevent redirect loops and provide escape hatch
+    const urlParams = Login.getHashParams()
+    // Skip if OIDC callback returned an error
+    if (urlParams.has('oidcError')) {
+      return true
+    }
+    // Skip if user explicitly requested no auto-login (escape hatch)
+    if (urlParams.get('noAutoLogin') === 'true') {
+      return true
+    }
+    return false
+  }
+
+  componentDidUpdate(prevProps) {
+    // Auto-redirect to OIDC login if enabled
+    const { loginStatus } = this.props
+    if (
+      loginStatus.status === 'notLoggedIn' &&
+      loginStatus.oidcEnabled &&
+      loginStatus.oidcAutoLogin &&
+      !loginStatus.noUsers &&
+      prevProps.loginStatus.status !== loginStatus.status &&
+      !this.shouldSkipAutoLogin()
+    ) {
+      window.location.href = loginStatus.oidcLoginUrl
+    }
   }
 
   handleClick() {
@@ -165,6 +211,33 @@ class Login extends Component {
                               )}
                           </Col>
                         </Row>
+                        {this.props.loginStatus.oidcEnabled && (
+                          <>
+                            <Row className="mt-4 mb-3">
+                              <Col className="text-center">
+                                <span className="text-muted">
+                                  &#8212; or &#8212;
+                                </span>
+                              </Col>
+                            </Row>
+                            <Row>
+                              <Col className="text-center">
+                                <Button
+                                  onClick={() => {
+                                    window.location.href =
+                                      this.props.loginStatus.oidcLoginUrl
+                                  }}
+                                  color="secondary"
+                                  className="px-4"
+                                >
+                                  <i className="fa fa-sign-in" />{' '}
+                                  {this.props.loginStatus.oidcProviderName ||
+                                    'SSO Login'}
+                                </Button>
+                              </Col>
+                            </Row>
+                          </>
+                        )}
                       </CardBody>
                     </Card>
                   </CardGroup>

--- a/packages/server-admin-ui/src/views/security/Login.js
+++ b/packages/server-admin-ui/src/views/security/Login.js
@@ -62,6 +62,25 @@ class Login extends Component {
     return false
   }
 
+  tryAutoLogin() {
+    const { loginStatus } = this.props
+    if (
+      loginStatus.status === 'notLoggedIn' &&
+      loginStatus.oidcEnabled &&
+      loginStatus.oidcAutoLogin &&
+      !loginStatus.noUsers &&
+      !this.shouldSkipAutoLogin()
+    ) {
+      window.location.href = loginStatus.oidcLoginUrl
+    }
+  }
+
+  componentDidMount() {
+    // Auto-redirect to OIDC login if enabled and user is not logged in
+    // This handles the case when Login is rendered fresh with loginStatus already populated
+    this.tryAutoLogin()
+  }
+
   componentDidUpdate(prevProps) {
     // Auto-redirect to OIDC login if enabled
     const { loginStatus } = this.props

--- a/packages/server-admin-ui/src/views/security/OIDCSettings.js
+++ b/packages/server-admin-ui/src/views/security/OIDCSettings.js
@@ -1,0 +1,619 @@
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import {
+  Alert,
+  Button,
+  Card,
+  CardHeader,
+  CardBody,
+  CardFooter,
+  Input,
+  Form,
+  Col,
+  Label,
+  FormGroup,
+  FormText,
+  Collapse,
+  Badge,
+  Row,
+  Spinner
+} from 'reactstrap'
+
+class OIDCSettings extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      hasData: false,
+      isOpen: false,
+      isSaving: false,
+      isTesting: false,
+      testResult: null,
+      saveResult: null,
+      // Form fields
+      enabled: false,
+      issuer: '',
+      clientId: '',
+      clientSecret: '',
+      clientSecretSet: false,
+      providerName: 'SSO Login',
+      defaultPermission: 'readonly',
+      autoCreateUsers: true,
+      autoLogin: false,
+      adminGroups: '',
+      readwriteGroups: '',
+      groupsAttribute: 'groups',
+      scope: 'openid email profile',
+      envOverrides: {}
+    }
+
+    this.handleChange = this.handleChange.bind(this)
+    this.handleSaveConfig = this.handleSaveConfig.bind(this)
+    this.handleTestConnection = this.handleTestConnection.bind(this)
+    this.toggle = this.toggle.bind(this)
+  }
+
+  componentDidMount() {
+    if (this.props.loginStatus.authenticationRequired) {
+      this.fetchOIDCConfig()
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (
+      this.props.loginStatus.authenticationRequired !==
+      prevProps.loginStatus.authenticationRequired
+    ) {
+      this.fetchOIDCConfig()
+    }
+  }
+
+  fetchOIDCConfig() {
+    fetch(`${window.serverRoutesPrefix}/security/oidc`, {
+      credentials: 'include'
+    })
+      .then((response) => response.json())
+      .then((data) => {
+        this.setState({
+          hasData: true,
+          enabled: data.enabled || false,
+          issuer: data.issuer || '',
+          clientId: data.clientId || '',
+          clientSecret: '',
+          clientSecretSet: data.clientSecretSet || false,
+          providerName: data.providerName || 'SSO Login',
+          defaultPermission: data.defaultPermission || 'readonly',
+          autoCreateUsers:
+            data.autoCreateUsers !== undefined ? data.autoCreateUsers : true,
+          autoLogin: data.autoLogin || false,
+          adminGroups: Array.isArray(data.adminGroups)
+            ? data.adminGroups.join(', ')
+            : data.adminGroups || '',
+          readwriteGroups: Array.isArray(data.readwriteGroups)
+            ? data.readwriteGroups.join(', ')
+            : data.readwriteGroups || '',
+          groupsAttribute: data.groupsAttribute || 'groups',
+          scope: data.scope || 'openid email profile',
+          envOverrides: data.envOverrides || {}
+        })
+      })
+      .catch((err) => {
+        console.error('Failed to fetch OIDC config:', err)
+      })
+  }
+
+  handleChange(event) {
+    const value =
+      event.target.type === 'checkbox'
+        ? event.target.checked
+        : event.target.value
+    this.setState({ [event.target.name]: value })
+  }
+
+  handleSaveConfig() {
+    this.setState({ isSaving: true, saveResult: null })
+
+    const payload = {
+      enabled: this.state.enabled,
+      issuer: this.state.issuer,
+      clientId: this.state.clientId,
+      clientSecret: this.state.clientSecret,
+      providerName: this.state.providerName,
+      defaultPermission: this.state.defaultPermission,
+      autoCreateUsers: this.state.autoCreateUsers,
+      autoLogin: this.state.autoLogin,
+      adminGroups: this.state.adminGroups,
+      readwriteGroups: this.state.readwriteGroups,
+      groupsAttribute: this.state.groupsAttribute,
+      scope: this.state.scope
+    }
+
+    fetch(`${window.serverRoutesPrefix}/security/oidc`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(payload),
+      credentials: 'include'
+    })
+      .then((response) => {
+        if (!response.ok) {
+          return response.json().then((data) => {
+            throw new Error(data.error || 'Failed to save configuration')
+          })
+        }
+        return response.json()
+      })
+      .then(() => {
+        this.setState({
+          isSaving: false,
+          saveResult: { success: true, message: 'OIDC configuration saved' },
+          clientSecret: '',
+          clientSecretSet: true
+        })
+        this.fetchOIDCConfig()
+      })
+      .catch((err) => {
+        this.setState({
+          isSaving: false,
+          saveResult: { success: false, message: err.message }
+        })
+      })
+  }
+
+  handleTestConnection() {
+    if (!this.state.issuer) {
+      this.setState({
+        testResult: { success: false, message: 'Issuer URL is required' }
+      })
+      return
+    }
+
+    this.setState({ isTesting: true, testResult: null })
+
+    fetch(`${window.serverRoutesPrefix}/security/oidc/test`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ issuer: this.state.issuer }),
+      credentials: 'include'
+    })
+      .then((response) => {
+        if (!response.ok) {
+          return response.json().then((data) => {
+            throw new Error(data.error || 'Connection test failed')
+          })
+        }
+        return response.json()
+      })
+      .then((data) => {
+        this.setState({
+          isTesting: false,
+          testResult: {
+            success: true,
+            message: `Connected to ${data.issuer}`,
+            endpoints: {
+              authorization: data.authorization_endpoint,
+              token: data.token_endpoint
+            }
+          }
+        })
+      })
+      .catch((err) => {
+        this.setState({
+          isTesting: false,
+          testResult: { success: false, message: err.message }
+        })
+      })
+  }
+
+  toggle() {
+    this.setState({ isOpen: !this.state.isOpen })
+  }
+
+  isFieldDisabled(fieldName) {
+    return this.state.envOverrides[fieldName] === true
+  }
+
+  renderEnvBadge(fieldName) {
+    if (this.state.envOverrides[fieldName]) {
+      return (
+        <Badge
+          color="warning"
+          className="ml-2"
+          title="Set via environment variable"
+        >
+          ENV
+        </Badge>
+      )
+    }
+    return null
+  }
+
+  render() {
+    if (!this.state.hasData || !this.props.loginStatus.authenticationRequired) {
+      return null
+    }
+
+    return (
+      <Card>
+        <CardHeader onClick={this.toggle} style={{ cursor: 'pointer' }}>
+          <i className="fa fa-openid" /> OIDC / SSO Authentication
+          <span className="float-right">
+            {this.state.enabled && (
+              <Badge color="success" className="mr-2">
+                Enabled
+              </Badge>
+            )}
+            <i
+              className={`fa fa-chevron-${this.state.isOpen ? 'up' : 'down'}`}
+            />
+          </span>
+        </CardHeader>
+        <Collapse isOpen={this.state.isOpen}>
+          <CardBody>
+            <Form
+              action=""
+              method="post"
+              encType="multipart/form-data"
+              className="form-horizontal"
+            >
+              <FormGroup row>
+                <Col xs="0" md="3">
+                  <Label>Enable OIDC</Label>
+                  {this.renderEnvBadge('enabled')}
+                </Col>
+                <Col md="9">
+                  <FormGroup check>
+                    <div>
+                      <Label className="switch switch-text switch-primary">
+                        <Input
+                          type="checkbox"
+                          name="enabled"
+                          className="switch-input"
+                          onChange={this.handleChange}
+                          checked={this.state.enabled}
+                          disabled={this.isFieldDisabled('enabled')}
+                        />
+                        <span
+                          className="switch-label"
+                          data-on="Yes"
+                          data-off="No"
+                        />
+                        <span className="switch-handle" />
+                      </Label>
+                    </div>
+                  </FormGroup>
+                  <FormText color="muted">
+                    Enable OpenID Connect authentication
+                  </FormText>
+                </Col>
+              </FormGroup>
+
+              <FormGroup row>
+                <Col md="3">
+                  <Label htmlFor="issuer">Issuer URL</Label>
+                  {this.renderEnvBadge('issuer')}
+                </Col>
+                <Col xs="12" md="9">
+                  <Row>
+                    <Col md="8">
+                      <Input
+                        type="text"
+                        name="issuer"
+                        placeholder="https://auth.example.com"
+                        onChange={this.handleChange}
+                        value={this.state.issuer}
+                        disabled={this.isFieldDisabled('issuer')}
+                      />
+                    </Col>
+                    <Col md="4">
+                      <Button
+                        color="secondary"
+                        onClick={this.handleTestConnection}
+                        disabled={this.state.isTesting || !this.state.issuer}
+                      >
+                        {this.state.isTesting ? (
+                          <Spinner size="sm" />
+                        ) : (
+                          <i className="fa fa-plug" />
+                        )}{' '}
+                        Test Connection
+                      </Button>
+                    </Col>
+                  </Row>
+                  <FormText color="muted">
+                    The OIDC provider&apos;s issuer URL (e.g., Keycloak,
+                    Authentik)
+                  </FormText>
+                  {this.state.testResult && (
+                    <Alert
+                      color={
+                        this.state.testResult.success ? 'success' : 'danger'
+                      }
+                      className="mt-2"
+                    >
+                      {this.state.testResult.message}
+                    </Alert>
+                  )}
+                </Col>
+              </FormGroup>
+
+              <FormGroup row>
+                <Col md="3">
+                  <Label htmlFor="clientId">Client ID</Label>
+                  {this.renderEnvBadge('clientId')}
+                </Col>
+                <Col xs="12" md="9">
+                  <Input
+                    type="text"
+                    name="clientId"
+                    placeholder="signalk-server"
+                    onChange={this.handleChange}
+                    value={this.state.clientId}
+                    disabled={this.isFieldDisabled('clientId')}
+                  />
+                  <FormText color="muted">
+                    Client ID from your OIDC provider
+                  </FormText>
+                </Col>
+              </FormGroup>
+
+              <FormGroup row>
+                <Col md="3">
+                  <Label htmlFor="clientSecret">Client Secret</Label>
+                  {this.renderEnvBadge('clientSecret')}
+                </Col>
+                <Col xs="12" md="9">
+                  <Input
+                    type="password"
+                    name="clientSecret"
+                    placeholder={
+                      this.state.clientSecretSet
+                        ? '••••••••••••••••'
+                        : 'Enter client secret'
+                    }
+                    onChange={this.handleChange}
+                    value={this.state.clientSecret}
+                    disabled={this.isFieldDisabled('clientSecret')}
+                  />
+                  <FormText color="muted">
+                    {this.state.clientSecretSet
+                      ? 'Leave empty to keep existing secret'
+                      : 'Client secret from your OIDC provider'}
+                  </FormText>
+                </Col>
+              </FormGroup>
+
+              <FormGroup row>
+                <Col md="3">
+                  <Label htmlFor="providerName">Provider Display Name</Label>
+                  {this.renderEnvBadge('providerName')}
+                </Col>
+                <Col xs="12" md="9">
+                  <Input
+                    type="text"
+                    name="providerName"
+                    placeholder="SSO Login"
+                    onChange={this.handleChange}
+                    value={this.state.providerName}
+                    disabled={this.isFieldDisabled('providerName')}
+                  />
+                  <FormText color="muted">
+                    Text shown on the SSO login button
+                  </FormText>
+                </Col>
+              </FormGroup>
+
+              <hr />
+              <h5>Permission Mapping</h5>
+
+              <FormGroup row>
+                <Col md="3">
+                  <Label htmlFor="defaultPermission">Default Permission</Label>
+                  {this.renderEnvBadge('defaultPermission')}
+                </Col>
+                <Col xs="12" md="4">
+                  <Input
+                    type="select"
+                    name="defaultPermission"
+                    value={this.state.defaultPermission}
+                    onChange={this.handleChange}
+                    disabled={this.isFieldDisabled('defaultPermission')}
+                  >
+                    <option value="readonly">Read Only</option>
+                    <option value="readwrite">Read/Write</option>
+                    <option value="admin">Admin</option>
+                  </Input>
+                  <FormText color="muted">
+                    Permission for users not matching any group mapping
+                  </FormText>
+                </Col>
+              </FormGroup>
+
+              <FormGroup row>
+                <Col md="3">
+                  <Label htmlFor="adminGroups">Admin Groups</Label>
+                  {this.renderEnvBadge('adminGroups')}
+                </Col>
+                <Col xs="12" md="9">
+                  <Input
+                    type="text"
+                    name="adminGroups"
+                    placeholder="admins, sk-admin"
+                    onChange={this.handleChange}
+                    value={this.state.adminGroups}
+                    disabled={this.isFieldDisabled('adminGroups')}
+                  />
+                  <FormText color="muted">
+                    Comma-separated list of groups that grant admin permission
+                  </FormText>
+                </Col>
+              </FormGroup>
+
+              <FormGroup row>
+                <Col md="3">
+                  <Label htmlFor="readwriteGroups">Read/Write Groups</Label>
+                  {this.renderEnvBadge('readwriteGroups')}
+                </Col>
+                <Col xs="12" md="9">
+                  <Input
+                    type="text"
+                    name="readwriteGroups"
+                    placeholder="users, operators"
+                    onChange={this.handleChange}
+                    value={this.state.readwriteGroups}
+                    disabled={this.isFieldDisabled('readwriteGroups')}
+                  />
+                  <FormText color="muted">
+                    Comma-separated list of groups that grant read/write
+                    permission
+                  </FormText>
+                </Col>
+              </FormGroup>
+
+              <FormGroup row>
+                <Col md="3">
+                  <Label htmlFor="groupsAttribute">Groups Attribute</Label>
+                  {this.renderEnvBadge('groupsAttribute')}
+                </Col>
+                <Col xs="12" md="9">
+                  <Input
+                    type="text"
+                    name="groupsAttribute"
+                    placeholder="groups"
+                    onChange={this.handleChange}
+                    value={this.state.groupsAttribute}
+                    disabled={this.isFieldDisabled('groupsAttribute')}
+                  />
+                  <FormText color="muted">
+                    ID token claim containing user groups (e.g., groups, roles,
+                    memberOf)
+                  </FormText>
+                </Col>
+              </FormGroup>
+
+              <hr />
+              <h5>User Settings</h5>
+
+              <FormGroup row>
+                <Col xs="0" md="3">
+                  <Label>Auto-Create Users</Label>
+                  {this.renderEnvBadge('autoCreateUsers')}
+                </Col>
+                <Col md="9">
+                  <FormGroup check>
+                    <div>
+                      <Label className="switch switch-text switch-primary">
+                        <Input
+                          type="checkbox"
+                          name="autoCreateUsers"
+                          className="switch-input"
+                          onChange={this.handleChange}
+                          checked={this.state.autoCreateUsers}
+                          disabled={this.isFieldDisabled('autoCreateUsers')}
+                        />
+                        <span
+                          className="switch-label"
+                          data-on="Yes"
+                          data-off="No"
+                        />
+                        <span className="switch-handle" />
+                      </Label>
+                    </div>
+                  </FormGroup>
+                  <FormText color="muted">
+                    Automatically create local user on first OIDC login
+                  </FormText>
+                </Col>
+              </FormGroup>
+
+              <FormGroup row>
+                <Col xs="0" md="3">
+                  <Label>Auto-Login</Label>
+                  {this.renderEnvBadge('autoLogin')}
+                </Col>
+                <Col md="9">
+                  <FormGroup check>
+                    <div>
+                      <Label className="switch switch-text switch-primary">
+                        <Input
+                          type="checkbox"
+                          name="autoLogin"
+                          className="switch-input"
+                          onChange={this.handleChange}
+                          checked={this.state.autoLogin}
+                          disabled={this.isFieldDisabled('autoLogin')}
+                        />
+                        <span
+                          className="switch-label"
+                          data-on="Yes"
+                          data-off="No"
+                        />
+                        <span className="switch-handle" />
+                      </Label>
+                    </div>
+                  </FormGroup>
+                  <FormText color="muted">
+                    Automatically redirect to OIDC login when not authenticated
+                  </FormText>
+                </Col>
+              </FormGroup>
+
+              <hr />
+              <h5>Advanced</h5>
+
+              <FormGroup row>
+                <Col md="3">
+                  <Label htmlFor="scope">Scope</Label>
+                  {this.renderEnvBadge('scope')}
+                </Col>
+                <Col xs="12" md="9">
+                  <Input
+                    type="text"
+                    name="scope"
+                    placeholder="openid email profile"
+                    onChange={this.handleChange}
+                    value={this.state.scope}
+                    disabled={this.isFieldDisabled('scope')}
+                  />
+                  <FormText color="muted">
+                    Space-separated OAuth scopes (must include
+                    &apos;openid&apos;)
+                  </FormText>
+                </Col>
+              </FormGroup>
+            </Form>
+          </CardBody>
+          <CardFooter>
+            {this.state.saveResult && (
+              <Alert
+                color={this.state.saveResult.success ? 'success' : 'danger'}
+                className="mb-2"
+              >
+                {this.state.saveResult.message}
+              </Alert>
+            )}
+            <Button
+              size="sm"
+              color="primary"
+              onClick={this.handleSaveConfig}
+              disabled={this.state.isSaving}
+            >
+              {this.state.isSaving ? (
+                <Spinner size="sm" />
+              ) : (
+                <i className="fa fa-dot-circle-o" />
+              )}{' '}
+              Save
+            </Button>
+          </CardFooter>
+        </Collapse>
+      </Card>
+    )
+  }
+}
+
+const mapStateToProps = ({ loginStatus }) => ({ loginStatus })
+
+export default connect(mapStateToProps)(OIDCSettings)

--- a/packages/server-admin-ui/src/views/security/OIDCSettings.js
+++ b/packages/server-admin-ui/src/views/security/OIDCSettings.js
@@ -15,8 +15,7 @@ import {
   FormText,
   Collapse,
   Badge,
-  Row,
-  Spinner
+  Row
 } from 'reactstrap'
 
 class OIDCSettings extends Component {
@@ -313,11 +312,9 @@ class OIDCSettings extends Component {
                         onClick={this.handleTestConnection}
                         disabled={this.state.isTesting || !this.state.issuer}
                       >
-                        {this.state.isTesting ? (
-                          <Spinner size="sm" />
-                        ) : (
-                          <i className="fa fa-plug" />
-                        )}{' '}
+                        <i
+                          className={`fa fa-${this.state.isTesting ? 'spinner fa-spin' : 'plug'}`}
+                        />{' '}
                         Test Connection
                       </Button>
                     </Col>
@@ -600,11 +597,9 @@ class OIDCSettings extends Component {
               onClick={this.handleSaveConfig}
               disabled={this.state.isSaving}
             >
-              {this.state.isSaving ? (
-                <Spinner size="sm" />
-              ) : (
-                <i className="fa fa-dot-circle-o" />
-              )}{' '}
+              <i
+                className={`fa fa-${this.state.isSaving ? 'spinner fa-spin' : 'dot-circle-o'}`}
+              />{' '}
               Save
             </Button>
           </CardFooter>

--- a/packages/server-admin-ui/src/views/security/Settings.js
+++ b/packages/server-admin-ui/src/views/security/Settings.js
@@ -14,6 +14,7 @@ import {
   FormText
 } from 'reactstrap'
 import EnableSecurity from './EnableSecurity'
+import OIDCSettings from './OIDCSettings'
 
 export function fetchSecurityConfig() {
   fetch(`${window.serverRoutesPrefix}/security/config`, {
@@ -251,6 +252,7 @@ class Settings extends Component {
                   </Button>
                 </CardFooter>
               </Card>
+              <OIDCSettings />
             </div>
           )}
       </div>

--- a/packages/server-admin-ui/src/views/security/Users.js
+++ b/packages/server-admin-ui/src/views/security/Users.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import {
+  Badge,
   Button,
   Card,
   CardHeader,
@@ -10,6 +11,7 @@ import {
   Col,
   Label,
   FormGroup,
+  FormText,
   Table,
   Row
 } from 'reactstrap'
@@ -186,6 +188,7 @@ class Users extends Component {
                     <tr>
                       <th>User ID</th>
                       <th>Type</th>
+                      <th>Auth</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -195,8 +198,24 @@ class Users extends Component {
                           key={user.userId}
                           onClick={this.userClicked.bind(this, user, index)}
                         >
-                          <td>{user.userId}</td>
+                          <td>
+                            {user.userId}
+                            {user.email && (
+                              <small className="text-muted ml-2">
+                                ({user.email})
+                              </small>
+                            )}
+                          </td>
                           <td>{convertType(user.type)}</td>
+                          <td>
+                            {user.isOIDC ? (
+                              <Badge color="info" title="Authenticated via SSO">
+                                SSO
+                              </Badge>
+                            ) : (
+                              <Badge color="secondary">Local</Badge>
+                            )}
+                          </td>
                         </tr>
                       )
                     })}
@@ -216,6 +235,11 @@ class Users extends Component {
                   <CardHeader>
                     <i className="fa fa-align-justify" />
                     User
+                    {this.state.selectedUser.isOIDC && (
+                      <Badge color="info" className="ml-2">
+                        SSO User
+                      </Badge>
+                    )}
                   </CardHeader>
                   <CardBody>
                     <FormGroup row>
@@ -236,32 +260,56 @@ class Users extends Component {
                         )}
                       </Col>
                     </FormGroup>
-                    <FormGroup row>
-                      <Col md="2">
-                        <Label htmlFor="password">Password</Label>
-                      </Col>
-                      <Col xs="12" md="9">
-                        <Input
-                          type="password"
-                          name="password"
-                          value={this.state.selectedUser.password}
-                          onChange={this.handleUserChange}
-                        />
-                      </Col>
-                    </FormGroup>
-                    <FormGroup row>
-                      <Col md="2">
-                        <Label htmlFor="text-input">Confirm Password</Label>
-                      </Col>
-                      <Col xs="12" md="9">
-                        <Input
-                          type="password"
-                          name="confirmPassword"
-                          value={this.state.selectedUser.confirmPassword}
-                          onChange={this.handleUserChange}
-                        />
-                      </Col>
-                    </FormGroup>
+                    {this.state.selectedUser.email && (
+                      <FormGroup row>
+                        <Col md="2">
+                          <Label>Email</Label>
+                        </Col>
+                        <Col xs="12" md="9">
+                          <Label>{this.state.selectedUser.email}</Label>
+                        </Col>
+                      </FormGroup>
+                    )}
+                    {this.state.selectedUser.isOIDC ? (
+                      <FormGroup row>
+                        <Col md="12">
+                          <FormText color="muted">
+                            <i className="fa fa-info-circle" /> This user
+                            authenticates via Single Sign-On. Password cannot be
+                            set for SSO users.
+                          </FormText>
+                        </Col>
+                      </FormGroup>
+                    ) : (
+                      <>
+                        <FormGroup row>
+                          <Col md="2">
+                            <Label htmlFor="password">Password</Label>
+                          </Col>
+                          <Col xs="12" md="9">
+                            <Input
+                              type="password"
+                              name="password"
+                              value={this.state.selectedUser.password}
+                              onChange={this.handleUserChange}
+                            />
+                          </Col>
+                        </FormGroup>
+                        <FormGroup row>
+                          <Col md="2">
+                            <Label htmlFor="text-input">Confirm Password</Label>
+                          </Col>
+                          <Col xs="12" md="9">
+                            <Input
+                              type="password"
+                              name="confirmPassword"
+                              value={this.state.selectedUser.confirmPassword}
+                              onChange={this.handleUserChange}
+                            />
+                          </Col>
+                        </FormGroup>
+                      </>
+                    )}
                     <FormGroup row>
                       <Col md="2">
                         <Label htmlFor="select">Permissions</Label>

--- a/src/oidc/authorization.ts
+++ b/src/oidc/authorization.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 Matti Airas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { OIDCAuthState, OIDCConfig, OIDCProviderMetadata } from './types'
+import { calculateCodeChallenge } from './pkce'
+
+/**
+ * Build the authorization URL for the OIDC flow
+ * @param config OIDC configuration
+ * @param metadata Discovery document metadata
+ * @param authState The auth state containing state, nonce, code verifier
+ * @returns The authorization URL to redirect the user to
+ */
+export function buildAuthorizationUrl(
+  config: OIDCConfig,
+  metadata: OIDCProviderMetadata,
+  authState: OIDCAuthState
+): string {
+  const url = new URL(metadata.authorization_endpoint)
+
+  // Required OAuth 2.0 parameters
+  url.searchParams.set('response_type', 'code')
+  url.searchParams.set('client_id', config.clientId)
+  url.searchParams.set('redirect_uri', authState.redirectUri)
+  url.searchParams.set('scope', config.scope)
+
+  // State for CSRF protection
+  url.searchParams.set('state', authState.state)
+
+  // Nonce for ID token replay protection
+  url.searchParams.set('nonce', authState.nonce)
+
+  // PKCE parameters (S256 method)
+  url.searchParams.set(
+    'code_challenge',
+    calculateCodeChallenge(authState.codeVerifier)
+  )
+  url.searchParams.set('code_challenge_method', 'S256')
+
+  return url.toString()
+}

--- a/src/oidc/config.ts
+++ b/src/oidc/config.ts
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2025 Matti Airas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  OIDCConfig,
+  OIDCError,
+  OIDC_DEFAULTS,
+  PartialOIDCConfig
+} from './types'
+
+/**
+ * Parse OIDC configuration from environment variables
+ */
+export function parseEnvConfig(): PartialOIDCConfig {
+  const config: PartialOIDCConfig = {}
+
+  if (process.env.SIGNALK_OIDC_ENABLED !== undefined) {
+    config.enabled = process.env.SIGNALK_OIDC_ENABLED.toLowerCase() === 'true'
+  }
+
+  if (process.env.SIGNALK_OIDC_ISSUER) {
+    config.issuer = process.env.SIGNALK_OIDC_ISSUER
+  }
+
+  if (process.env.SIGNALK_OIDC_CLIENT_ID) {
+    config.clientId = process.env.SIGNALK_OIDC_CLIENT_ID
+  }
+
+  if (process.env.SIGNALK_OIDC_CLIENT_SECRET) {
+    config.clientSecret = process.env.SIGNALK_OIDC_CLIENT_SECRET
+  }
+
+  if (process.env.SIGNALK_OIDC_REDIRECT_URI) {
+    config.redirectUri = process.env.SIGNALK_OIDC_REDIRECT_URI
+  }
+
+  if (process.env.SIGNALK_OIDC_SCOPE) {
+    config.scope = process.env.SIGNALK_OIDC_SCOPE
+  }
+
+  if (process.env.SIGNALK_OIDC_DEFAULT_PERMISSION) {
+    const perm = process.env.SIGNALK_OIDC_DEFAULT_PERMISSION.toLowerCase()
+    if (perm === 'readonly' || perm === 'readwrite' || perm === 'admin') {
+      config.defaultPermission = perm
+    }
+  }
+
+  if (process.env.SIGNALK_OIDC_AUTO_CREATE_USERS !== undefined) {
+    config.autoCreateUsers =
+      process.env.SIGNALK_OIDC_AUTO_CREATE_USERS.toLowerCase() === 'true'
+  }
+
+  return config
+}
+
+/**
+ * Merge configuration from security.json and environment variables
+ * Priority: env vars > security.json > defaults
+ */
+export function mergeConfigs(
+  securityJsonConfig: PartialOIDCConfig,
+  envConfig: PartialOIDCConfig
+): OIDCConfig {
+  return {
+    enabled:
+      envConfig.enabled ?? securityJsonConfig.enabled ?? OIDC_DEFAULTS.enabled,
+    issuer: envConfig.issuer ?? securityJsonConfig.issuer ?? '',
+    clientId: envConfig.clientId ?? securityJsonConfig.clientId ?? '',
+    clientSecret:
+      envConfig.clientSecret ?? securityJsonConfig.clientSecret ?? '',
+    redirectUri: envConfig.redirectUri ?? securityJsonConfig.redirectUri,
+    scope: envConfig.scope ?? securityJsonConfig.scope ?? OIDC_DEFAULTS.scope,
+    defaultPermission:
+      envConfig.defaultPermission ??
+      securityJsonConfig.defaultPermission ??
+      OIDC_DEFAULTS.defaultPermission,
+    autoCreateUsers:
+      envConfig.autoCreateUsers ??
+      securityJsonConfig.autoCreateUsers ??
+      OIDC_DEFAULTS.autoCreateUsers
+  }
+}
+
+/**
+ * Validate OIDC configuration
+ * @throws OIDCError if configuration is invalid
+ */
+export function validateOIDCConfig(
+  config: Partial<OIDCConfig>
+): asserts config is OIDCConfig {
+  // If OIDC is disabled, no validation needed
+  if (config.enabled === false || config.enabled === undefined) {
+    return
+  }
+
+  // Validate required fields when enabled
+  if (!config.issuer) {
+    throw new OIDCError(
+      'OIDC issuer is required when enabled',
+      'CONFIG_INVALID'
+    )
+  }
+
+  if (!config.clientId) {
+    throw new OIDCError(
+      'OIDC clientId is required when enabled',
+      'CONFIG_INVALID'
+    )
+  }
+
+  if (!config.clientSecret) {
+    throw new OIDCError(
+      'OIDC clientSecret is required when enabled',
+      'CONFIG_INVALID'
+    )
+  }
+
+  // Validate issuer is a valid URL
+  try {
+    new URL(config.issuer)
+  } catch {
+    throw new OIDCError(
+      `OIDC issuer must be a valid URL: ${config.issuer}`,
+      'CONFIG_INVALID'
+    )
+  }
+
+  // Validate scope contains 'openid'
+  if (config.scope && !config.scope.split(' ').includes('openid')) {
+    throw new OIDCError('OIDC scope must contain "openid"', 'CONFIG_INVALID')
+  }
+
+  // Validate defaultPermission
+  if (
+    config.defaultPermission &&
+    !['readonly', 'readwrite', 'admin'].includes(config.defaultPermission)
+  ) {
+    throw new OIDCError(
+      `OIDC defaultPermission must be one of: readonly, readwrite, admin`,
+      'CONFIG_INVALID'
+    )
+  }
+}
+
+/**
+ * Parse OIDC configuration from security.json and environment variables
+ * @param securityConfig The security configuration object (may contain oidc section)
+ * @returns Complete OIDC configuration
+ * @throws OIDCError if configuration is invalid
+ */
+export function parseOIDCConfig(securityConfig: {
+  oidc?: PartialOIDCConfig
+}): OIDCConfig {
+  const securityJsonConfig = securityConfig.oidc ?? {}
+  const envConfig = parseEnvConfig()
+  const merged = mergeConfigs(securityJsonConfig, envConfig)
+
+  validateOIDCConfig(merged)
+
+  return merged
+}
+
+/**
+ * Check if OIDC is enabled
+ */
+export function isOIDCEnabled(config: OIDCConfig): boolean {
+  return config.enabled === true
+}

--- a/src/oidc/config.ts
+++ b/src/oidc/config.ts
@@ -88,6 +88,17 @@ export function parseEnvConfig(): PartialOIDCConfig {
     config.groupsAttribute = process.env.SIGNALK_OIDC_GROUPS_ATTRIBUTE
   }
 
+  // Parse provider name (display name for login button)
+  if (process.env.SIGNALK_OIDC_PROVIDER_NAME) {
+    config.providerName = process.env.SIGNALK_OIDC_PROVIDER_NAME
+  }
+
+  // Parse auto login (auto-redirect to OIDC when not authenticated)
+  if (process.env.SIGNALK_OIDC_AUTO_LOGIN !== undefined) {
+    config.autoLogin =
+      process.env.SIGNALK_OIDC_AUTO_LOGIN.toLowerCase() === 'true'
+  }
+
   return config
 }
 
@@ -120,7 +131,15 @@ export function mergeConfigs(
     readwriteGroups:
       envConfig.readwriteGroups ?? securityJsonConfig.readwriteGroups,
     groupsAttribute:
-      envConfig.groupsAttribute ?? securityJsonConfig.groupsAttribute
+      envConfig.groupsAttribute ?? securityJsonConfig.groupsAttribute,
+    providerName:
+      envConfig.providerName ??
+      securityJsonConfig.providerName ??
+      OIDC_DEFAULTS.providerName,
+    autoLogin:
+      envConfig.autoLogin ??
+      securityJsonConfig.autoLogin ??
+      OIDC_DEFAULTS.autoLogin
   }
 }
 

--- a/src/oidc/config.ts
+++ b/src/oidc/config.ts
@@ -63,6 +63,31 @@ export function parseEnvConfig(): PartialOIDCConfig {
       process.env.SIGNALK_OIDC_AUTO_CREATE_USERS.toLowerCase() === 'true'
   }
 
+  // Parse admin groups from comma-separated string
+  if (process.env.SIGNALK_OIDC_ADMIN_GROUPS) {
+    const groups = process.env.SIGNALK_OIDC_ADMIN_GROUPS.split(',')
+      .map((g) => g.trim())
+      .filter((g) => g.length > 0)
+    if (groups.length > 0) {
+      config.adminGroups = groups
+    }
+  }
+
+  // Parse readwrite groups from comma-separated string
+  if (process.env.SIGNALK_OIDC_READWRITE_GROUPS) {
+    const groups = process.env.SIGNALK_OIDC_READWRITE_GROUPS.split(',')
+      .map((g) => g.trim())
+      .filter((g) => g.length > 0)
+    if (groups.length > 0) {
+      config.readwriteGroups = groups
+    }
+  }
+
+  // Parse groups attribute (ID token claim key for groups)
+  if (process.env.SIGNALK_OIDC_GROUPS_ATTRIBUTE) {
+    config.groupsAttribute = process.env.SIGNALK_OIDC_GROUPS_ATTRIBUTE
+  }
+
   return config
 }
 
@@ -90,7 +115,12 @@ export function mergeConfigs(
     autoCreateUsers:
       envConfig.autoCreateUsers ??
       securityJsonConfig.autoCreateUsers ??
-      OIDC_DEFAULTS.autoCreateUsers
+      OIDC_DEFAULTS.autoCreateUsers,
+    adminGroups: envConfig.adminGroups ?? securityJsonConfig.adminGroups,
+    readwriteGroups:
+      envConfig.readwriteGroups ?? securityJsonConfig.readwriteGroups,
+    groupsAttribute:
+      envConfig.groupsAttribute ?? securityJsonConfig.groupsAttribute
   }
 }
 

--- a/src/oidc/discovery.ts
+++ b/src/oidc/discovery.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2025 Matti Airas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DiscoveryCache, OIDCError, OIDCProviderMetadata } from './types'
+
+const CACHE_TTL_MS = 60 * 60 * 1000 // 1 hour
+
+// In-memory cache for discovery documents
+const discoveryCache = new Map<string, DiscoveryCache>()
+
+// Fetch function that can be overridden for testing
+type FetchFn = typeof fetch
+let fetchFn: FetchFn = fetch
+
+/**
+ * Set the fetch function (for testing)
+ */
+export function setFetchFunction(fn: FetchFn): void {
+  fetchFn = fn
+}
+
+/**
+ * Reset the fetch function to the default
+ */
+export function resetFetchFunction(): void {
+  fetchFn = fetch
+}
+
+/**
+ * Fetch the OpenID Connect discovery document from an issuer
+ * @param issuer The OIDC issuer URL
+ * @returns The parsed discovery document
+ * @throws OIDCError if fetch fails or document is invalid
+ */
+export async function fetchDiscoveryDocument(
+  issuer: string
+): Promise<OIDCProviderMetadata> {
+  const discoveryUrl = `${issuer.replace(/\/$/, '')}/.well-known/openid-configuration`
+
+  let response: Response
+  try {
+    response = await fetchFn(discoveryUrl)
+  } catch (err) {
+    throw new OIDCError(
+      `Failed to fetch OIDC discovery document from ${discoveryUrl}: ${err}`,
+      'DISCOVERY_FAILED',
+      err instanceof Error ? err : undefined
+    )
+  }
+
+  if (!response.ok) {
+    throw new OIDCError(
+      `OIDC discovery document request failed with status ${response.status}`,
+      'DISCOVERY_FAILED'
+    )
+  }
+
+  let metadata: OIDCProviderMetadata
+  try {
+    metadata = (await response.json()) as OIDCProviderMetadata
+  } catch (err) {
+    throw new OIDCError(
+      'Failed to parse OIDC discovery document as JSON',
+      'DISCOVERY_FAILED',
+      err instanceof Error ? err : undefined
+    )
+  }
+
+  // Validate required fields
+  if (
+    !metadata.issuer ||
+    !metadata.authorization_endpoint ||
+    !metadata.token_endpoint ||
+    !metadata.jwks_uri
+  ) {
+    throw new OIDCError(
+      'OIDC discovery document is missing required fields',
+      'DISCOVERY_FAILED'
+    )
+  }
+
+  return metadata
+}
+
+/**
+ * Get the discovery document for an issuer, using cache if available
+ * @param issuer The OIDC issuer URL
+ * @returns The discovery document
+ */
+export async function getDiscoveryDocument(
+  issuer: string
+): Promise<OIDCProviderMetadata> {
+  const cached = discoveryCache.get(issuer)
+  const now = Date.now()
+
+  if (cached && cached.expiresAt > now) {
+    return cached.metadata
+  }
+
+  const metadata = await fetchDiscoveryDocument(issuer)
+
+  discoveryCache.set(issuer, {
+    metadata,
+    fetchedAt: now,
+    expiresAt: now + CACHE_TTL_MS
+  })
+
+  return metadata
+}
+
+/**
+ * Clear the discovery document cache
+ * Useful for testing and when re-configuring OIDC
+ */
+export function clearDiscoveryCache(): void {
+  discoveryCache.clear()
+}

--- a/src/oidc/id-token-validation.ts
+++ b/src/oidc/id-token-validation.ts
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2025 Matti Airas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { OIDCConfig, OIDCError, OIDCProviderMetadata } from './types'
+
+// Type imports for jose (for TypeScript)
+import type { JSONWebKeySet as JoseJSONWebKeySet, JWTPayload } from 'jose'
+
+// Dynamic import for jose (ESM-only module)
+
+type JoseModule = typeof import('jose')
+let joseModule: JoseModule | null = null
+
+async function getJose(): Promise<JoseModule> {
+  if (!joseModule) {
+    joseModule = await import('jose')
+  }
+  return joseModule
+}
+
+/**
+ * JSON Web Key Set structure
+ */
+export interface JSONWebKeySet {
+  keys: Array<{
+    kty: string
+    kid?: string
+    use?: string
+    alg?: string
+    [key: string]: unknown
+  }>
+}
+
+/**
+ * ID Token claims after validation
+ */
+export interface ValidatedIdTokenClaims {
+  iss: string
+  sub: string
+  aud: string | string[]
+  exp: number
+  iat: number
+  nonce?: string
+  email?: string
+  name?: string
+  preferred_username?: string
+  groups?: string[]
+  [key: string]: unknown
+}
+
+// Fetch function that can be overridden for testing
+type FetchFn = typeof fetch
+let fetchFn: FetchFn = fetch
+
+/**
+ * Set the fetch function (for testing)
+ */
+export function setFetchFunction(fn: FetchFn): void {
+  fetchFn = fn
+}
+
+/**
+ * Reset the fetch function to the default
+ */
+export function resetFetchFunction(): void {
+  fetchFn = fetch
+}
+
+// JWKS cache
+interface JwksCache {
+  jwks: JSONWebKeySet
+  fetchedAt: number
+}
+
+const jwksCache = new Map<string, JwksCache>()
+const JWKS_CACHE_TTL_MS = 60 * 60 * 1000 // 1 hour
+
+/**
+ * Clear the JWKS cache
+ */
+export function clearJwksCache(): void {
+  jwksCache.clear()
+}
+
+/**
+ * Fetch JWKS from the provider
+ * @param metadata Provider metadata containing jwks_uri
+ * @returns The JWKS
+ */
+export async function fetchJwks(
+  metadata: OIDCProviderMetadata
+): Promise<JSONWebKeySet> {
+  const cached = jwksCache.get(metadata.jwks_uri)
+  if (cached && Date.now() - cached.fetchedAt < JWKS_CACHE_TTL_MS) {
+    return cached.jwks
+  }
+
+  let response: Response
+  try {
+    response = await fetchFn(metadata.jwks_uri)
+  } catch (err) {
+    throw new OIDCError(
+      `Failed to fetch JWKS from ${metadata.jwks_uri}: ${err}`,
+      'DISCOVERY_FAILED',
+      err instanceof Error ? err : undefined
+    )
+  }
+
+  if (!response.ok) {
+    throw new OIDCError(
+      `JWKS fetch failed with status ${response.status}`,
+      'DISCOVERY_FAILED'
+    )
+  }
+
+  let jwks: JSONWebKeySet
+  try {
+    jwks = (await response.json()) as JSONWebKeySet
+  } catch (err) {
+    throw new OIDCError(
+      'Failed to parse JWKS as JSON',
+      'DISCOVERY_FAILED',
+      err instanceof Error ? err : undefined
+    )
+  }
+
+  // Cache the JWKS
+  jwksCache.set(metadata.jwks_uri, {
+    jwks,
+    fetchedAt: Date.now()
+  })
+
+  return jwks
+}
+
+/**
+ * Validate an ID token according to OIDC spec
+ *
+ * Validates:
+ * - Signature using provider's JWKS
+ * - Issuer matches expected issuer
+ * - Audience contains client_id
+ * - Token is not expired (with 5 min clock skew tolerance)
+ * - Nonce matches expected nonce
+ *
+ * @param idToken The ID token string
+ * @param config OIDC configuration
+ * @param metadata Provider metadata
+ * @param expectedNonce The nonce from the auth state
+ * @returns Validated claims from the ID token
+ * @throws OIDCError if validation fails
+ */
+export async function validateIdToken(
+  idToken: string,
+  config: OIDCConfig,
+  metadata: OIDCProviderMetadata,
+  expectedNonce: string
+): Promise<ValidatedIdTokenClaims> {
+  // Dynamically import jose (ESM-only module)
+  const jose = await getJose()
+
+  // Fetch JWKS
+  const jwks = await fetchJwks(metadata)
+
+  // Create JWKS from the fetched keys
+  const keySet = jose.createLocalJWKSet(jwks as JoseJSONWebKeySet)
+
+  // Verify the token signature and decode claims
+  let payload: JWTPayload
+  try {
+    const result = await jose.jwtVerify(idToken, keySet, {
+      issuer: config.issuer,
+      audience: config.clientId,
+      clockTolerance: 300 // 5 minutes clock skew tolerance
+    })
+    payload = result.payload
+  } catch (err) {
+    // Check error types by name since we can't use instanceof with dynamically imported classes
+    const errorName = err instanceof Error ? err.constructor.name : ''
+    const errorMessage = err instanceof Error ? err.message.toLowerCase() : ''
+
+    if (errorName === 'JWTExpired') {
+      throw new OIDCError(
+        'ID token has expired',
+        'INVALID_TOKEN',
+        err instanceof Error ? err : undefined
+      )
+    }
+    if (errorName === 'JWTClaimValidationFailed') {
+      if (errorMessage.includes('iss') || errorMessage.includes('issuer')) {
+        throw new OIDCError(
+          `ID token issuer mismatch: expected ${config.issuer}`,
+          'INVALID_TOKEN',
+          err instanceof Error ? err : undefined
+        )
+      }
+      if (errorMessage.includes('aud') || errorMessage.includes('audience')) {
+        throw new OIDCError(
+          `ID token audience mismatch: expected ${config.clientId}`,
+          'INVALID_TOKEN',
+          err instanceof Error ? err : undefined
+        )
+      }
+    }
+    throw new OIDCError(
+      `ID token validation failed: ${err}`,
+      'INVALID_TOKEN',
+      err instanceof Error ? err : undefined
+    )
+  }
+
+  // Validate nonce
+  if (payload.nonce !== expectedNonce) {
+    throw new OIDCError(
+      `ID token nonce mismatch: expected ${expectedNonce}, got ${payload.nonce}`,
+      'INVALID_TOKEN'
+    )
+  }
+
+  // Validate required claims exist
+  if (typeof payload.sub !== 'string' || !payload.sub) {
+    throw new OIDCError(
+      'ID token missing required "sub" claim',
+      'INVALID_TOKEN'
+    )
+  }
+
+  return payload as unknown as ValidatedIdTokenClaims
+}

--- a/src/oidc/index.ts
+++ b/src/oidc/index.ts
@@ -37,3 +37,4 @@ export {
   findOrCreateOIDCUser,
   type OIDCAuthDependencies
 } from './oidc-auth'
+export * from './permission-mapping'

--- a/src/oidc/index.ts
+++ b/src/oidc/index.ts
@@ -24,7 +24,7 @@ export {
   clearDiscoveryCache
 } from './discovery'
 export * from './authorization'
-export { exchangeAuthorizationCode } from './token-exchange'
+export { exchangeAuthorizationCode, fetchUserinfo } from './token-exchange'
 export {
   validateIdToken,
   fetchJwks,

--- a/src/oidc/index.ts
+++ b/src/oidc/index.ts
@@ -32,3 +32,8 @@ export {
   type ValidatedIdTokenClaims
 } from './id-token-validation'
 export * from './user-info'
+export {
+  registerOIDCRoutes,
+  findOrCreateOIDCUser,
+  type OIDCAuthDependencies
+} from './oidc-auth'

--- a/src/oidc/index.ts
+++ b/src/oidc/index.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Matti Airas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './types'
+export * from './config'
+export * from './pkce'
+export * from './state'
+export {
+  fetchDiscoveryDocument,
+  getDiscoveryDocument,
+  clearDiscoveryCache
+} from './discovery'
+export * from './authorization'
+export { exchangeAuthorizationCode } from './token-exchange'
+export {
+  validateIdToken,
+  fetchJwks,
+  clearJwksCache,
+  type ValidatedIdTokenClaims
+} from './id-token-validation'
+export * from './user-info'

--- a/src/oidc/oidc-auth.ts
+++ b/src/oidc/oidc-auth.ts
@@ -26,6 +26,7 @@ import {
   buildAuthorizationUrl,
   exchangeAuthorizationCode,
   validateIdToken,
+  fetchUserinfo,
   mapGroupsToPermission,
   STATE_COOKIE_NAME,
   STATE_MAX_AGE_MS,
@@ -338,6 +339,14 @@ export function registerOIDCRoutes(
           metadata,
           authState.nonce
         )
+
+        // Fetch additional claims from userinfo endpoint
+        // ID token typically only contains minimal claims; userinfo has groups, email, etc.
+        const userinfoClaims = await fetchUserinfo(tokens.accessToken, metadata)
+        if (userinfoClaims) {
+          // Merge userinfo claims into ID token claims (userinfo takes precedence)
+          Object.assign(claims, userinfoClaims)
+        }
 
         // Clear state cookie after successful validation
         res.clearCookie(STATE_COOKIE_NAME)

--- a/src/oidc/oidc-auth.ts
+++ b/src/oidc/oidc-auth.ts
@@ -1,0 +1,341 @@
+/*
+ * Copyright 2025 Matti Airas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Request, Response, Application } from 'express'
+import { createDebug } from '../debug'
+import {
+  isOIDCEnabled,
+  createAuthState,
+  validateState,
+  encryptState,
+  decryptState,
+  getDiscoveryDocument,
+  buildAuthorizationUrl,
+  exchangeAuthorizationCode,
+  validateIdToken,
+  STATE_COOKIE_NAME,
+  STATE_MAX_AGE_MS,
+  OIDCError,
+  OIDCConfig,
+  OIDCUserInfo
+} from './index'
+import { User, SecurityConfig } from '../security'
+
+const debug = createDebug('signalk-server:oidc-auth')
+const skAuthPrefix = '/signalk/v1/auth'
+
+/**
+ * Dependencies injected by tokensecurity.
+ * This interface defines the contract between tokensecurity and OIDC authentication.
+ */
+export interface OIDCAuthDependencies {
+  /** Get the current security configuration */
+  getConfiguration: () => SecurityConfig
+  /** Get parsed OIDC configuration */
+  getOIDCConfig: () => OIDCConfig
+  /** Set session cookies after successful authentication */
+  setSessionCookie: (
+    res: Response,
+    req: Request,
+    token: string,
+    username: string,
+    options?: { rememberMe?: boolean }
+  ) => void
+  /** Clear session cookies on logout */
+  clearSessionCookie: (res: Response) => void
+  /** Generate a JWT for a user */
+  generateJWT: (userId: string, expiration?: string) => string
+  /** Save security configuration */
+  saveConfig: (
+    config: SecurityConfig,
+    callback: (err: Error | null) => void
+  ) => void
+}
+
+/**
+ * Validate that a URL is a safe relative path (prevents open redirect attacks)
+ */
+function isSafeRelativeUrl(url: unknown): url is string {
+  if (typeof url !== 'string' || !url) {
+    return false
+  }
+  // Must start with / but not // (which would be protocol-relative URL)
+  // Also reject URLs with backslashes or control characters
+  const hasControlChars = url.split('').some((char) => {
+    const code = char.charCodeAt(0)
+    return code >= 0 && code <= 31
+  })
+  return (
+    url.startsWith('/') &&
+    !url.startsWith('//') &&
+    !url.includes('\\') &&
+    !hasControlChars
+  )
+}
+
+/**
+ * Find or create a user from OIDC authentication.
+ * This function looks up existing users by OIDC subject+issuer, or creates
+ * a new user if auto-creation is enabled.
+ */
+export async function findOrCreateOIDCUser(
+  userInfo: OIDCUserInfo,
+  oidcConfig: OIDCConfig,
+  deps: Pick<OIDCAuthDependencies, 'getConfiguration' | 'saveConfig'>
+): Promise<User | null> {
+  const configuration = deps.getConfiguration()
+  const issuer = oidcConfig.issuer
+
+  // Look for existing user by OIDC sub + issuer
+  const user = configuration.users.find(
+    (u) => u.oidc && u.oidc.sub === userInfo.sub && u.oidc.issuer === issuer
+  )
+
+  if (user) {
+    debug(`OIDC: found existing user ${user.username}`)
+    return user
+  }
+
+  // User not found - check if auto-creation is enabled
+  if (!oidcConfig.autoCreateUsers) {
+    debug('OIDC: user not found and auto-creation disabled')
+    return null
+  }
+
+  // Create new user
+  const username =
+    userInfo.preferredUsername || userInfo.email || `oidc-${userInfo.sub}`
+
+  // Check for username collision with non-OIDC user
+  const existingUser = configuration.users.find(
+    (u) => u.username === username && !u.oidc
+  )
+  const finalUsername = existingUser
+    ? `${username}-${userInfo.sub.substring(0, 8)}`
+    : username
+
+  const newUser: User = {
+    username: finalUsername,
+    type: oidcConfig.defaultPermission,
+    oidc: {
+      sub: userInfo.sub,
+      issuer
+    }
+  }
+
+  debug(
+    `OIDC: creating new user ${newUser.username} with permission ${newUser.type}`
+  )
+  configuration.users.push(newUser)
+
+  // Save configuration (async, but don't block)
+  deps.saveConfig(configuration, (err) => {
+    if (err) {
+      console.error('Failed to save OIDC user:', err)
+    }
+  })
+
+  return newUser
+}
+
+/**
+ * Register OIDC authentication routes.
+ * This function adds the OIDC login, callback, and status endpoints to the Express app.
+ */
+export function registerOIDCRoutes(
+  app: Application,
+  deps: OIDCAuthDependencies
+): void {
+  // OIDC login route - initiates the OIDC flow
+  app.get(`${skAuthPrefix}/oidc/login`, async (req: Request, res: Response) => {
+    try {
+      const oidcConfig = deps.getOIDCConfig()
+      if (!isOIDCEnabled(oidcConfig)) {
+        res.status(500).json({ error: 'OIDC is not configured' })
+        return
+      }
+
+      const metadata = await getDiscoveryDocument(oidcConfig.issuer)
+
+      // Build redirect URI
+      const protocol = req.secure ? 'https' : 'http'
+      const host = req.get('host')
+      const redirectUri =
+        oidcConfig.redirectUri ||
+        `${protocol}://${host}${skAuthPrefix}/oidc/callback`
+
+      // Store original destination (validated to prevent open redirect attacks)
+      const requestedRedirect = req.query.redirect
+      const originalUrl = isSafeRelativeUrl(requestedRedirect)
+        ? requestedRedirect
+        : '/'
+
+      // Create auth state
+      const authState = createAuthState(redirectUri, originalUrl)
+
+      // Encrypt and store state in cookie
+      const configuration = deps.getConfiguration()
+      const encryptedState = encryptState(authState, configuration.secretKey)
+
+      res.cookie(STATE_COOKIE_NAME, encryptedState, {
+        httpOnly: true,
+        secure: req.secure || req.headers['x-forwarded-proto'] === 'https',
+        sameSite: 'lax',
+        maxAge: STATE_MAX_AGE_MS
+      })
+
+      // Build and redirect to authorization URL
+      const authUrl = buildAuthorizationUrl(oidcConfig, metadata, authState)
+      debug(`OIDC: redirecting to ${authUrl}`)
+      res.redirect(authUrl)
+    } catch (err) {
+      console.error('OIDC login error:', err)
+      res.status(500).json({
+        error: 'OIDC login failed',
+        message: err instanceof Error ? err.message : String(err)
+      })
+    }
+  })
+
+  // OIDC callback route - handles the response from the OIDC provider
+  app.get(
+    `${skAuthPrefix}/oidc/callback`,
+    async (req: Request, res: Response) => {
+      try {
+        const { code, state, error, error_description } = req.query as Record<
+          string,
+          string
+        >
+
+        // Check for OIDC error from provider
+        if (error) {
+          res.clearCookie(STATE_COOKIE_NAME)
+          console.error(`OIDC error: ${error} - ${error_description}`)
+          res.status(400).json({
+            error: 'OIDC authentication failed',
+            message: error_description || error
+          })
+          return
+        }
+
+        // Validate required parameters
+        if (!code || !state) {
+          res.clearCookie(STATE_COOKIE_NAME)
+          res.status(400).json({ error: 'Missing code or state parameter' })
+          return
+        }
+
+        // Get and validate stored state
+        const stateCookie = req.cookies[STATE_COOKIE_NAME]
+        if (!stateCookie) {
+          res.status(400).json({ error: 'Missing state cookie' })
+          return
+        }
+
+        const configuration = deps.getConfiguration()
+        let authState
+        try {
+          authState = decryptState(stateCookie, configuration.secretKey)
+          validateState(state, authState)
+        } catch (err) {
+          res.clearCookie(STATE_COOKIE_NAME)
+          console.error('OIDC state validation failed:', err)
+          res.status(400).json({
+            error: 'State validation failed',
+            message:
+              err instanceof OIDCError
+                ? err.message
+                : 'Invalid or expired state'
+          })
+          return
+        }
+
+        const oidcConfig = deps.getOIDCConfig()
+        const metadata = await getDiscoveryDocument(oidcConfig.issuer)
+
+        // Exchange code for tokens
+        const tokens = await exchangeAuthorizationCode(
+          code,
+          oidcConfig,
+          metadata,
+          authState
+        )
+
+        // Validate ID token signature and claims (including nonce)
+        const claims = await validateIdToken(
+          tokens.idToken,
+          oidcConfig,
+          metadata,
+          authState.nonce
+        )
+
+        // Clear state cookie after successful validation
+        res.clearCookie(STATE_COOKIE_NAME)
+
+        // Extract user info from validated claims
+        const userInfo: OIDCUserInfo = {
+          sub: claims.sub as string,
+          email: claims.email as string | undefined,
+          name: claims.name as string | undefined,
+          preferredUsername: claims.preferred_username as string | undefined,
+          groups: claims.groups as string[] | undefined
+        }
+        debug(`OIDC: user authenticated: ${userInfo.sub}`)
+
+        // Find or create user
+        const user = await findOrCreateOIDCUser(userInfo, oidcConfig, deps)
+        if (!user) {
+          res.status(403).json({
+            error: 'User creation denied',
+            message: 'OIDC user auto-creation is disabled'
+          })
+          return
+        }
+
+        // Issue local JWT token
+        const token = deps.generateJWT(user.username)
+
+        // Set session cookies using the shared helper (fixes security issue!)
+        deps.setSessionCookie(res, req, token, user.username, {
+          rememberMe: true
+        })
+
+        // Redirect to original destination
+        res.redirect(authState.originalUrl)
+      } catch (err) {
+        console.error('OIDC callback error:', err)
+        res.status(500).json({
+          error: 'OIDC authentication failed',
+          message: err instanceof Error ? err.message : String(err)
+        })
+      }
+    }
+  )
+
+  // OIDC status endpoint - returns OIDC configuration status
+  app.get(`${skAuthPrefix}/oidc/status`, (_req: Request, res: Response) => {
+    try {
+      const oidcConfig = deps.getOIDCConfig()
+      res.json({
+        enabled: isOIDCEnabled(oidcConfig),
+        issuer: oidcConfig.enabled ? oidcConfig.issuer : undefined,
+        loginUrl: oidcConfig.enabled ? `${skAuthPrefix}/oidc/login` : undefined
+      })
+    } catch (_err) {
+      res.json({ enabled: false })
+    }
+  })
+}

--- a/src/oidc/oidc-auth.ts
+++ b/src/oidc/oidc-auth.ts
@@ -338,4 +338,68 @@ export function registerOIDCRoutes(
       res.json({ enabled: false })
     }
   })
+
+  // OIDC logout endpoint - clears local session and optionally redirects to provider logout
+  app.get(
+    `${skAuthPrefix}/oidc/logout`,
+    async (req: Request, res: Response) => {
+      try {
+        // Clear local session cookies
+        deps.clearSessionCookie(res)
+
+        // Get post-logout redirect URI (validated to prevent open redirect attacks)
+        const requestedRedirect = req.query.redirect
+        const postLogoutRedirect = isSafeRelativeUrl(requestedRedirect)
+          ? requestedRedirect
+          : '/'
+
+        // Check if OIDC is enabled and provider supports RP-initiated logout
+        const oidcConfig = deps.getOIDCConfig()
+        if (!isOIDCEnabled(oidcConfig)) {
+          // OIDC not enabled, just redirect locally
+          res.redirect(postLogoutRedirect)
+          return
+        }
+
+        // Fetch discovery document to check for end_session_endpoint
+        let metadata
+        try {
+          metadata = await getDiscoveryDocument(oidcConfig.issuer)
+        } catch (err) {
+          debug('OIDC: failed to fetch discovery document for logout:', err)
+          // Fall back to local redirect
+          res.redirect(postLogoutRedirect)
+          return
+        }
+
+        if (!metadata.end_session_endpoint) {
+          // Provider doesn't support RP-initiated logout
+          debug('OIDC: provider does not support end_session_endpoint')
+          res.redirect(postLogoutRedirect)
+          return
+        }
+
+        // Build logout URL with post_logout_redirect_uri
+        const protocol = req.secure ? 'https' : 'http'
+        const host = req.get('host')
+        const fullPostLogoutUri = `${protocol}://${host}${postLogoutRedirect}`
+
+        const logoutUrl = new URL(metadata.end_session_endpoint)
+        logoutUrl.searchParams.set(
+          'post_logout_redirect_uri',
+          fullPostLogoutUri
+        )
+        // Note: We don't send id_token_hint as we don't persist the ID token
+        // The provider should still be able to identify the session via cookies
+
+        debug(`OIDC: redirecting to logout URL: ${logoutUrl.toString()}`)
+        res.redirect(logoutUrl.toString())
+      } catch (err) {
+        console.error('OIDC logout error:', err)
+        // On error, still clear cookies and redirect to home
+        deps.clearSessionCookie(res)
+        res.redirect('/')
+      }
+    }
+  )
 }

--- a/src/oidc/oidc-auth.ts
+++ b/src/oidc/oidc-auth.ts
@@ -26,6 +26,7 @@ import {
   buildAuthorizationUrl,
   exchangeAuthorizationCode,
   validateIdToken,
+  mapGroupsToPermission,
   STATE_COOKIE_NAME,
   STATE_MAX_AGE_MS,
   OIDCError,
@@ -36,6 +37,21 @@ import { User, SecurityConfig } from '../security'
 
 const debug = createDebug('signalk-server:oidc-auth')
 const skAuthPrefix = '/signalk/v1/auth'
+
+/**
+ * Compare two arrays for equality, ignoring order
+ */
+function arraysEqualIgnoringOrder(
+  arr1: string[] | undefined,
+  arr2: string[] | undefined
+): boolean {
+  if (arr1 === arr2) return true
+  if (!arr1 || !arr2) return arr1 === arr2
+  if (arr1.length !== arr2.length) return false
+  const sorted1 = [...arr1].sort()
+  const sorted2 = [...arr2].sort()
+  return sorted1.every((val, idx) => val === sorted2[idx])
+}
 
 /**
  * Dependencies injected by tokensecurity.
@@ -90,6 +106,10 @@ function isSafeRelativeUrl(url: unknown): url is string {
  * Find or create a user from OIDC authentication.
  * This function looks up existing users by OIDC subject+issuer, or creates
  * a new user if auto-creation is enabled.
+ *
+ * For existing users, permissions are recalculated on each login based on
+ * current group memberships. This allows permission changes to take effect
+ * when group assignments change in the identity provider.
  */
 export async function findOrCreateOIDCUser(
   userInfo: OIDCUserInfo,
@@ -99,6 +119,18 @@ export async function findOrCreateOIDCUser(
   const configuration = deps.getConfiguration()
   const issuer = oidcConfig.issuer
 
+  // Calculate permission based on user's groups
+  const mappedPermission = mapGroupsToPermission(userInfo.groups, oidcConfig)
+
+  // Build OIDC metadata to store with user
+  const oidcMetadata = {
+    sub: userInfo.sub,
+    issuer,
+    email: userInfo.email,
+    name: userInfo.name,
+    groups: userInfo.groups
+  }
+
   // Look for existing user by OIDC sub + issuer
   const user = configuration.users.find(
     (u) => u.oidc && u.oidc.sub === userInfo.sub && u.oidc.issuer === issuer
@@ -106,6 +138,33 @@ export async function findOrCreateOIDCUser(
 
   if (user) {
     debug(`OIDC: found existing user ${user.username}`)
+
+    // Check if anything changed
+    const previousPermission = user.type
+    const permissionChanged = previousPermission !== mappedPermission
+    const metadataChanged =
+      user.oidc?.email !== oidcMetadata.email ||
+      user.oidc?.name !== oidcMetadata.name ||
+      !arraysEqualIgnoringOrder(user.oidc?.groups, oidcMetadata.groups)
+
+    if (permissionChanged) {
+      debug(
+        `OIDC: updating user ${user.username} permission from ${previousPermission} to ${mappedPermission}`
+      )
+      user.type = mappedPermission
+    }
+
+    // Only save if something changed
+    if (permissionChanged || metadataChanged) {
+      user.oidc = oidcMetadata
+
+      deps.saveConfig(configuration, (err) => {
+        if (err) {
+          console.error('Failed to update OIDC user:', err)
+        }
+      })
+    }
+
     return user
   }
 
@@ -129,11 +188,8 @@ export async function findOrCreateOIDCUser(
 
   const newUser: User = {
     username: finalUsername,
-    type: oidcConfig.defaultPermission,
-    oidc: {
-      sub: userInfo.sub,
-      issuer
-    }
+    type: mappedPermission,
+    oidc: oidcMetadata
   }
 
   debug(

--- a/src/oidc/permission-mapping.ts
+++ b/src/oidc/permission-mapping.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 Matti Airas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { OIDCConfig, SignalKPermission } from './types'
+
+/**
+ * Check if two arrays have any common elements
+ */
+function hasIntersection(arr1: string[], arr2: string[]): boolean {
+  const set1 = new Set(arr1)
+  return arr2.some((item) => set1.has(item))
+}
+
+/**
+ * Map OIDC groups to Signal K permission level
+ *
+ * Priority:
+ * 1. If user is in any admin group → 'admin'
+ * 2. Else if user is in any readwrite group → 'readwrite'
+ * 3. Else → defaultPermission (typically 'readonly')
+ *
+ * **Limitations:**
+ * - Group matching is **case-sensitive** (e.g., 'Admins' ≠ 'admins')
+ * - Groups must be present in the **ID token** (not userinfo endpoint)
+ * - Use `groupsAttribute` config to specify a custom claim name
+ *
+ * @param userGroups - Groups the user belongs to (from OIDC claims)
+ * @param config - OIDC configuration with group mappings
+ * @returns The mapped permission level
+ */
+export function mapGroupsToPermission(
+  userGroups: string[] | undefined,
+  config: OIDCConfig
+): SignalKPermission {
+  // If user has no groups, return default permission
+  if (!userGroups || userGroups.length === 0) {
+    return config.defaultPermission
+  }
+
+  // Check admin groups first (highest priority)
+  if (config.adminGroups && config.adminGroups.length > 0) {
+    if (hasIntersection(userGroups, config.adminGroups)) {
+      return 'admin'
+    }
+  }
+
+  // Check readwrite groups
+  if (config.readwriteGroups && config.readwriteGroups.length > 0) {
+    if (hasIntersection(userGroups, config.readwriteGroups)) {
+      return 'readwrite'
+    }
+  }
+
+  // Fall back to default permission
+  return config.defaultPermission
+}

--- a/src/oidc/pkce.ts
+++ b/src/oidc/pkce.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 Matti Airas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { randomBytes, createHash } from 'crypto'
+
+/**
+ * Generate a cryptographically random code verifier for PKCE
+ * Per RFC 7636, the code verifier must be:
+ * - 43-128 characters long
+ * - Use only unreserved URI characters: [A-Za-z0-9-._~]
+ */
+export function generateCodeVerifier(): string {
+  // Generate 48 bytes of random data, which will produce 64 base64url chars
+  const buffer = randomBytes(48)
+  return buffer.toString('base64url').slice(0, 64) // Use 64 characters (within 43-128 range)
+}
+
+/**
+ * Calculate the code challenge from a code verifier using S256 method
+ * Per RFC 7636: code_challenge = BASE64URL(SHA256(code_verifier))
+ * @param verifier The code verifier string
+ * @returns The code challenge (base64url-encoded SHA256 hash)
+ */
+export function calculateCodeChallenge(verifier: string): string {
+  return createHash('sha256').update(verifier).digest('base64url')
+}

--- a/src/oidc/state.ts
+++ b/src/oidc/state.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2025 Matti Airas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  randomBytes,
+  createCipheriv,
+  createDecipheriv,
+  createHash
+} from 'crypto'
+import { OIDCAuthState, OIDCError, STATE_MAX_AGE_MS } from './types'
+import { generateCodeVerifier } from './pkce'
+
+const ALGORITHM = 'aes-256-gcm'
+const IV_LENGTH = 16
+const AUTH_TAG_LENGTH = 16
+
+/**
+ * Generate a cryptographically random state parameter
+ * Used for CSRF protection in OAuth2 flows
+ */
+export function generateState(): string {
+  return randomBytes(32).toString('base64url')
+}
+
+/**
+ * Generate a cryptographically random nonce
+ * Used for ID token replay protection
+ */
+export function generateNonce(): string {
+  return randomBytes(32).toString('base64url')
+}
+
+/**
+ * Create a complete auth state object for the OIDC flow
+ */
+export function createAuthState(
+  redirectUri: string,
+  originalUrl: string
+): OIDCAuthState {
+  return {
+    state: generateState(),
+    codeVerifier: generateCodeVerifier(),
+    nonce: generateNonce(),
+    redirectUri,
+    originalUrl,
+    createdAt: Date.now()
+  }
+}
+
+/**
+ * Validate that the returned state matches the stored state
+ * and that the state hasn't expired
+ */
+export function validateState(
+  returnedState: string,
+  storedState: OIDCAuthState
+): void {
+  if (returnedState !== storedState.state) {
+    throw new OIDCError(
+      'State mismatch - possible CSRF attack',
+      'INVALID_STATE'
+    )
+  }
+
+  const age = Date.now() - storedState.createdAt
+  if (age > STATE_MAX_AGE_MS) {
+    throw new OIDCError(
+      `State expired (${Math.round(age / 1000)}s old, max ${STATE_MAX_AGE_MS / 1000}s)`,
+      'STATE_EXPIRED'
+    )
+  }
+}
+
+/**
+ * Derive a 32-byte encryption key from the secret key
+ */
+function deriveKey(secretKey: string): Buffer {
+  return createHash('sha256').update(secretKey).digest()
+}
+
+/**
+ * Encrypt the auth state for storage in a cookie
+ * Uses AES-256-GCM for authenticated encryption
+ */
+export function encryptState(state: OIDCAuthState, secretKey: string): string {
+  const key = deriveKey(secretKey)
+  const iv = randomBytes(IV_LENGTH)
+  const cipher = createCipheriv(ALGORITHM, key, iv)
+
+  const plaintext = JSON.stringify(state)
+  const encrypted = Buffer.concat([
+    cipher.update(plaintext, 'utf8'),
+    cipher.final()
+  ])
+  const authTag = cipher.getAuthTag()
+
+  // Combine IV + authTag + ciphertext
+  const combined = Buffer.concat([iv, authTag, encrypted])
+  return combined.toString('base64url')
+}
+
+/**
+ * Decrypt the auth state from a cookie
+ */
+export function decryptState(
+  encryptedState: string,
+  secretKey: string
+): OIDCAuthState {
+  const key = deriveKey(secretKey)
+  const combined = Buffer.from(encryptedState, 'base64url')
+
+  // Extract IV, authTag, and ciphertext
+  const iv = combined.subarray(0, IV_LENGTH)
+  const authTag = combined.subarray(IV_LENGTH, IV_LENGTH + AUTH_TAG_LENGTH)
+  const ciphertext = combined.subarray(IV_LENGTH + AUTH_TAG_LENGTH)
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv)
+  decipher.setAuthTag(authTag)
+
+  const decrypted = Buffer.concat([
+    decipher.update(ciphertext),
+    decipher.final()
+  ])
+
+  return JSON.parse(decrypted.toString('utf8')) as OIDCAuthState
+}

--- a/src/oidc/token-exchange.ts
+++ b/src/oidc/token-exchange.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2025 Matti Airas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  OIDCAuthState,
+  OIDCConfig,
+  OIDCError,
+  OIDCProviderMetadata,
+  OIDCTokens
+} from './types'
+
+// Fetch function that can be overridden for testing
+type FetchFn = typeof fetch
+let fetchFn: FetchFn = fetch
+
+/**
+ * Set the fetch function (for testing)
+ */
+export function setFetchFunction(fn: FetchFn): void {
+  fetchFn = fn
+}
+
+/**
+ * Reset the fetch function to the default
+ */
+export function resetFetchFunction(): void {
+  fetchFn = fetch
+}
+
+/**
+ * Exchange an authorization code for tokens
+ * @param code The authorization code from the callback
+ * @param config OIDC configuration
+ * @param metadata Discovery document metadata
+ * @param authState The auth state containing code verifier
+ * @returns The token response
+ * @throws OIDCError if the exchange fails
+ */
+export async function exchangeAuthorizationCode(
+  code: string,
+  config: OIDCConfig,
+  metadata: OIDCProviderMetadata,
+  authState: OIDCAuthState
+): Promise<OIDCTokens> {
+  const params = new URLSearchParams()
+  params.set('grant_type', 'authorization_code')
+  params.set('code', code)
+  params.set('redirect_uri', authState.redirectUri)
+  params.set('client_id', config.clientId)
+  params.set('client_secret', config.clientSecret)
+  params.set('code_verifier', authState.codeVerifier)
+
+  let response: Response
+  try {
+    response = await fetchFn(metadata.token_endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: params.toString()
+    })
+  } catch (err) {
+    throw new OIDCError(
+      `Token exchange request failed: ${err}`,
+      'TOKEN_EXCHANGE_FAILED',
+      err instanceof Error ? err : undefined
+    )
+  }
+
+  let body: {
+    access_token?: string
+    id_token?: string
+    refresh_token?: string
+    expires_in?: number
+    token_type?: string
+    error?: string
+    error_description?: string
+  }
+  try {
+    body = (await response.json()) as typeof body
+  } catch (err) {
+    throw new OIDCError(
+      'Failed to parse token response as JSON',
+      'TOKEN_EXCHANGE_FAILED',
+      err instanceof Error ? err : undefined
+    )
+  }
+
+  if (!response.ok) {
+    const errorMessage = body.error_description || body.error || 'Unknown error'
+    throw new OIDCError(
+      `Token exchange failed: ${body.error} - ${errorMessage}`,
+      'TOKEN_EXCHANGE_FAILED'
+    )
+  }
+
+  // Validate response structure
+  if (!body.access_token || !body.id_token) {
+    throw new OIDCError(
+      'Token response missing required fields (access_token, id_token)',
+      'TOKEN_EXCHANGE_FAILED'
+    )
+  }
+
+  return {
+    accessToken: body.access_token,
+    idToken: body.id_token,
+    refreshToken: body.refresh_token,
+    expiresIn: body.expires_in,
+    tokenType: body.token_type || 'Bearer'
+  }
+}

--- a/src/oidc/types.ts
+++ b/src/oidc/types.ts
@@ -15,6 +15,11 @@
  */
 
 /**
+ * Signal K permission type
+ */
+export type SignalKPermission = 'readonly' | 'readwrite' | 'admin'
+
+/**
  * OIDC Configuration - merged from environment variables and security.json
  */
 export interface OIDCConfig {
@@ -24,8 +29,19 @@ export interface OIDCConfig {
   clientSecret: string
   redirectUri?: string
   scope: string
-  defaultPermission: 'readonly' | 'readwrite' | 'admin'
+  defaultPermission: SignalKPermission
   autoCreateUsers: boolean
+  /** Groups that grant admin permission */
+  adminGroups?: string[]
+  /** Groups that grant readwrite permission */
+  readwriteGroups?: string[]
+  /**
+   * ID token claim key for groups (default: 'groups').
+   * Common alternatives: 'roles', 'memberOf', 'cognito:groups'
+   * Note: Groups must be present in the ID token, not the userinfo endpoint.
+   * Both array and single string values are supported.
+   */
+  groupsAttribute?: string
 }
 
 /**
@@ -38,8 +54,11 @@ export interface PartialOIDCConfig {
   clientSecret?: string
   redirectUri?: string
   scope?: string
-  defaultPermission?: 'readonly' | 'readwrite' | 'admin'
+  defaultPermission?: SignalKPermission
   autoCreateUsers?: boolean
+  adminGroups?: string[]
+  readwriteGroups?: string[]
+  groupsAttribute?: string
 }
 
 /**

--- a/src/oidc/types.ts
+++ b/src/oidc/types.ts
@@ -135,6 +135,8 @@ export interface OIDCProviderMetadata {
   jwks_uri: string
   response_types_supported: string[]
   code_challenge_methods_supported?: string[]
+  /** Endpoint for RP-initiated logout (optional, not all providers support) */
+  end_session_endpoint?: string
 }
 
 /**

--- a/src/oidc/types.ts
+++ b/src/oidc/types.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2025 Matti Airas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * OIDC Configuration - merged from environment variables and security.json
+ */
+export interface OIDCConfig {
+  enabled: boolean
+  issuer: string
+  clientId: string
+  clientSecret: string
+  redirectUri?: string
+  scope: string
+  defaultPermission: 'readonly' | 'readwrite' | 'admin'
+  autoCreateUsers: boolean
+}
+
+/**
+ * Partial OIDC config for merging from different sources
+ */
+export interface PartialOIDCConfig {
+  enabled?: boolean
+  issuer?: string
+  clientId?: string
+  clientSecret?: string
+  redirectUri?: string
+  scope?: string
+  defaultPermission?: 'readonly' | 'readwrite' | 'admin'
+  autoCreateUsers?: boolean
+}
+
+/**
+ * OIDC Authorization State - stored in cookie during auth flow
+ */
+export interface OIDCAuthState {
+  state: string
+  codeVerifier: string
+  nonce: string
+  redirectUri: string
+  originalUrl: string
+  createdAt: number
+}
+
+/**
+ * OIDC Token Response
+ */
+export interface OIDCTokens {
+  accessToken: string
+  idToken: string
+  refreshToken?: string
+  expiresIn?: number
+  tokenType: string
+}
+
+/**
+ * OIDC User Info - extracted from ID token or userinfo endpoint
+ */
+export interface OIDCUserInfo {
+  sub: string
+  email?: string
+  name?: string
+  preferredUsername?: string
+  groups?: string[]
+}
+
+/**
+ * OIDC user identifier stored in security.json
+ */
+export interface OIDCUserIdentifier {
+  sub: string
+  issuer: string
+}
+
+/**
+ * Discovery document cache entry
+ */
+export interface DiscoveryCache {
+  metadata: OIDCProviderMetadata
+  fetchedAt: number
+  expiresAt: number
+}
+
+/**
+ * OIDC Provider Metadata (subset of OpenID Discovery)
+ */
+export interface OIDCProviderMetadata {
+  issuer: string
+  authorization_endpoint: string
+  token_endpoint: string
+  userinfo_endpoint?: string
+  jwks_uri: string
+  response_types_supported: string[]
+  code_challenge_methods_supported?: string[]
+}
+
+/**
+ * OIDC Error codes
+ */
+export type OIDCErrorCode =
+  | 'DISCOVERY_FAILED'
+  | 'INVALID_STATE'
+  | 'STATE_EXPIRED'
+  | 'INVALID_TOKEN'
+  | 'TOKEN_EXCHANGE_FAILED'
+  | 'USER_INFO_FAILED'
+  | 'CONFIG_INVALID'
+  | 'PKCE_FAILED'
+  | 'NOT_CONFIGURED'
+  | 'USER_CREATION_DENIED'
+
+/**
+ * OIDC Error class
+ */
+export class OIDCError extends Error {
+  constructor(
+    message: string,
+    public code: OIDCErrorCode,
+    public cause?: Error
+  ) {
+    super(message)
+    this.name = 'OIDCError'
+    Error.captureStackTrace(this, OIDCError)
+  }
+}
+
+/**
+ * Default OIDC configuration values
+ */
+export const OIDC_DEFAULTS: Omit<
+  OIDCConfig,
+  'issuer' | 'clientId' | 'clientSecret'
+> = {
+  enabled: false,
+  scope: 'openid email profile',
+  defaultPermission: 'readonly',
+  autoCreateUsers: true
+}
+
+/**
+ * State cookie configuration
+ */
+export const STATE_COOKIE_NAME = 'OIDC_STATE'
+export const STATE_MAX_AGE_MS = 10 * 60 * 1000 // 10 minutes

--- a/src/oidc/types.ts
+++ b/src/oidc/types.ts
@@ -104,6 +104,7 @@ export interface OIDCProviderMetadata {
   jwks_uri: string
   response_types_supported: string[]
   code_challenge_methods_supported?: string[]
+  end_session_endpoint?: string
 }
 
 /**

--- a/src/oidc/types.ts
+++ b/src/oidc/types.ts
@@ -42,6 +42,16 @@ export interface OIDCConfig {
    * Both array and single string values are supported.
    */
   groupsAttribute?: string
+  /**
+   * Display name for the OIDC provider shown on the login button.
+   * Default: 'SSO Login'
+   */
+  providerName: string
+  /**
+   * If true, automatically redirect to OIDC login when not authenticated.
+   * Default: false
+   */
+  autoLogin: boolean
 }
 
 /**
@@ -59,6 +69,8 @@ export interface PartialOIDCConfig {
   adminGroups?: string[]
   readwriteGroups?: string[]
   groupsAttribute?: string
+  providerName?: string
+  autoLogin?: boolean
 }
 
 /**
@@ -123,7 +135,6 @@ export interface OIDCProviderMetadata {
   jwks_uri: string
   response_types_supported: string[]
   code_challenge_methods_supported?: string[]
-  end_session_endpoint?: string
 }
 
 /**
@@ -166,7 +177,9 @@ export const OIDC_DEFAULTS: Omit<
   enabled: false,
   scope: 'openid email profile',
   defaultPermission: 'readonly',
-  autoCreateUsers: true
+  autoCreateUsers: true,
+  providerName: 'SSO Login',
+  autoLogin: false
 }
 
 /**

--- a/src/oidc/user-info.ts
+++ b/src/oidc/user-info.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 Matti Airas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { OIDCError, OIDCUserInfo } from './types'
+
+/**
+ * Decode the payload of a JWT token (without verification)
+ * NOTE: This should only be used for debugging or after the token has been
+ * properly validated using validateIdToken(). For production use, always
+ * validate the token first using the id-token-validation module.
+ */
+export function decodeIdToken(idToken: string): Record<string, unknown> {
+  const parts = idToken.split('.')
+  if (parts.length !== 3) {
+    throw new OIDCError(
+      'Invalid ID token format - expected 3 parts',
+      'INVALID_TOKEN'
+    )
+  }
+
+  try {
+    const payload = Buffer.from(parts[1], 'base64url').toString('utf8')
+    return JSON.parse(payload)
+  } catch (err) {
+    throw new OIDCError(
+      'Failed to decode ID token payload',
+      'INVALID_TOKEN',
+      err instanceof Error ? err : undefined
+    )
+  }
+}
+
+/**
+ * Extract user information from an ID token
+ * @param idToken The ID token string
+ * @returns User information extracted from claims
+ * @throws OIDCError if the token is invalid or missing required claims
+ */
+export function extractUserInfo(idToken: string): OIDCUserInfo {
+  const claims = decodeIdToken(idToken)
+
+  if (typeof claims.sub !== 'string' || !claims.sub) {
+    throw new OIDCError(
+      'ID token missing required "sub" claim',
+      'INVALID_TOKEN'
+    )
+  }
+
+  return {
+    sub: claims.sub,
+    email: typeof claims.email === 'string' ? claims.email : undefined,
+    name: typeof claims.name === 'string' ? claims.name : undefined,
+    preferredUsername:
+      typeof claims.preferred_username === 'string'
+        ? claims.preferred_username
+        : undefined,
+    groups: Array.isArray(claims.groups)
+      ? (claims.groups as string[])
+      : undefined
+  }
+}

--- a/src/security.ts
+++ b/src/security.ts
@@ -60,10 +60,16 @@ export interface ACL {
     }>
   }>
 }
+export interface OIDCUserIdentifier {
+  sub: string
+  issuer: string
+}
+
 export interface User {
   username: string
   type: string
   password?: string
+  oidc?: OIDCUserIdentifier
 }
 export interface UserData {
   userId: string
@@ -93,6 +99,17 @@ export interface DeviceDataUpdate {
   description?: string
 }
 
+export interface OIDCSecurityConfig {
+  enabled: boolean
+  issuer: string
+  clientId: string
+  clientSecret: string
+  redirectUri?: string
+  scope?: string
+  defaultPermission?: 'readonly' | 'readwrite' | 'admin'
+  autoCreateUsers?: boolean
+}
+
 export interface SecurityConfig {
   immutableConfig: boolean
   allow_readonly: boolean
@@ -104,6 +121,7 @@ export interface SecurityConfig {
   secretKey: string
   users: User[]
   acls?: ACL[]
+  oidc?: OIDCSecurityConfig
 }
 
 export interface RequestStatusData {

--- a/src/security.ts
+++ b/src/security.ts
@@ -63,6 +63,12 @@ export interface ACL {
 export interface OIDCUserIdentifier {
   sub: string
   issuer: string
+  /** User's email from OIDC claims */
+  email?: string
+  /** User's display name from OIDC claims */
+  name?: string
+  /** User's groups from OIDC claims (used for permission mapping) */
+  groups?: string[]
 }
 
 export interface User {

--- a/src/tokensecurity.js
+++ b/src/tokensecurity.js
@@ -574,10 +574,20 @@ module.exports = function (app, config) {
   strategy.getUsers = (aConfig) => {
     if (aConfig && aConfig.users) {
       return aConfig.users.map((user) => {
-        return {
+        const userData = {
           userId: user.username,
-          type: user.type
+          type: user.type,
+          isOIDC: !!user.oidc
         }
+        // Include OIDC metadata for OIDC users
+        if (user.oidc) {
+          userData.oidc = {
+            issuer: user.oidc.issuer,
+            email: user.oidc.email,
+            name: user.oidc.name
+          }
+        }
+        return userData
       })
     } else {
       return []

--- a/src/tokensecurity.js
+++ b/src/tokensecurity.js
@@ -32,6 +32,23 @@ const {
 } = require('./requestResponse')
 const ms = require('ms')
 
+// OIDC imports
+import {
+  parseOIDCConfig,
+  isOIDCEnabled,
+  createAuthState,
+  validateState,
+  encryptState,
+  decryptState,
+  getDiscoveryDocument,
+  buildAuthorizationUrl,
+  exchangeAuthorizationCode,
+  validateIdToken,
+  STATE_COOKIE_NAME,
+  STATE_MAX_AGE_MS,
+  OIDCError
+} from './oidc'
+
 const CONFIG_PLUGINID = 'sk-simple-token-security-config'
 const passwordSaltRounds = 10
 const permissionDeniedMessage =
@@ -46,6 +63,30 @@ const BROWSER_LOGININFO_COOKIE_NAME = 'skLoginInfo'
 import { SERVERROUTESPREFIX } from './constants'
 
 const LOGIN_FAILED_MESSAGE = 'Invalid username/password'
+
+/**
+ * Validate that a URL is a safe relative path (prevents open redirect attacks)
+ * @param {string} url - The URL to validate
+ * @returns {boolean} - True if the URL is a safe relative path
+ */
+function isSafeRelativeUrl(url) {
+  if (typeof url !== 'string' || !url) {
+    return false
+  }
+  // Must start with / but not // (which would be protocol-relative URL)
+  // Also reject URLs with backslashes or control characters
+  // Check for control characters (ASCII 0-31) that could be used for URL manipulation
+  const hasControlChars = url.split('').some((char) => {
+    const code = char.charCodeAt(0)
+    return code >= 0 && code <= 31
+  })
+  return (
+    url.startsWith('/') &&
+    !url.startsWith('//') &&
+    !url.includes('\\') &&
+    !hasControlChars
+  )
+}
 
 module.exports = function (app, config) {
   const strategy = {}
@@ -116,6 +157,73 @@ module.exports = function (app, config) {
     return options
   }
   strategy.getConfiguration = getConfiguration
+
+  // Parse and cache OIDC configuration
+  let cachedOIDCConfig = null
+  function getOIDCConfig() {
+    if (!cachedOIDCConfig) {
+      cachedOIDCConfig = parseOIDCConfig(options)
+    }
+    return cachedOIDCConfig
+  }
+
+  // Find or create an OIDC user in the configuration
+  async function findOrCreateOIDCUser(userInfo, oidcConfig) {
+    const configuration = getConfiguration()
+    const issuer = oidcConfig.issuer
+
+    // Look for existing user by OIDC sub + issuer
+    let user = configuration.users.find(
+      (u) => u.oidc && u.oidc.sub === userInfo.sub && u.oidc.issuer === issuer
+    )
+
+    if (user) {
+      debug(`OIDC: found existing user ${user.username}`)
+      return user
+    }
+
+    // User not found - check if auto-creation is enabled
+    if (!oidcConfig.autoCreateUsers) {
+      debug(`OIDC: user not found and auto-creation disabled`)
+      return null
+    }
+
+    // Create new user
+    const username =
+      userInfo.preferredUsername || userInfo.email || `oidc-${userInfo.sub}`
+
+    // Check for username collision with non-OIDC user
+    const existingUser = configuration.users.find(
+      (u) => u.username === username && !u.oidc
+    )
+    const finalUsername = existingUser
+      ? `${username}-${userInfo.sub.substring(0, 8)}`
+      : username
+
+    user = {
+      username: finalUsername,
+      type: oidcConfig.defaultPermission,
+      oidc: {
+        sub: userInfo.sub,
+        issuer: issuer
+      }
+    }
+
+    debug(
+      `OIDC: creating new user ${user.username} with permission ${user.type}`
+    )
+    configuration.users.push(user)
+
+    // Save configuration (async, but don't block)
+    const { saveSecurityConfig } = require('./security')
+    saveSecurityConfig(app, configuration, (err) => {
+      if (err) {
+        console.error('Failed to save OIDC user:', err)
+      }
+    })
+
+    return user
+  }
 
   function getIsEnabled() {
     // var options = getOptions();
@@ -323,6 +431,198 @@ module.exports = function (app, config) {
       res.clearCookie('JAUTHENTICATION')
       res.clearCookie(BROWSER_LOGININFO_COOKIE_NAME)
       res.json('Logout OK')
+    })
+
+    // OIDC login route - initiates the OIDC flow
+    app.get(`${skAuthPrefix}/oidc/login`, async (req, res) => {
+      try {
+        const oidcConfig = getOIDCConfig()
+        if (!isOIDCEnabled(oidcConfig)) {
+          res.status(500).json({ error: 'OIDC is not configured' })
+          return
+        }
+
+        const metadata = await getDiscoveryDocument(oidcConfig.issuer)
+
+        // Build redirect URI
+        const protocol = req.secure ? 'https' : 'http'
+        const host = req.get('host')
+        const redirectUri =
+          oidcConfig.redirectUri ||
+          `${protocol}://${host}${skAuthPrefix}/oidc/callback`
+
+        // Store original destination (validated to prevent open redirect attacks)
+        const requestedRedirect = req.query.redirect
+        const originalUrl = isSafeRelativeUrl(requestedRedirect)
+          ? requestedRedirect
+          : '/'
+
+        // Create auth state
+        const authState = createAuthState(redirectUri, originalUrl)
+
+        // Encrypt and store state in cookie
+        const configuration = getConfiguration()
+        const encryptedState = encryptState(authState, configuration.secretKey)
+
+        res.cookie(STATE_COOKIE_NAME, encryptedState, {
+          httpOnly: true,
+          secure: req.secure,
+          sameSite: 'lax',
+          maxAge: STATE_MAX_AGE_MS
+        })
+
+        // Build and redirect to authorization URL
+        const authUrl = buildAuthorizationUrl(oidcConfig, metadata, authState)
+        debug(`OIDC: redirecting to ${authUrl}`)
+        res.redirect(authUrl)
+      } catch (err) {
+        console.error('OIDC login error:', err)
+        res.status(500).json({
+          error: 'OIDC login failed',
+          message: err instanceof Error ? err.message : String(err)
+        })
+      }
+    })
+
+    // OIDC callback route - handles the response from the OIDC provider
+    app.get(`${skAuthPrefix}/oidc/callback`, async (req, res) => {
+      try {
+        const { code, state, error, error_description } = req.query
+
+        // Check for OIDC error
+        if (error) {
+          res.clearCookie(STATE_COOKIE_NAME)
+          console.error(`OIDC error: ${error} - ${error_description}`)
+          res.status(400).json({
+            error: 'OIDC authentication failed',
+            message: error_description || error
+          })
+          return
+        }
+
+        // Validate required parameters
+        if (!code || !state) {
+          res.clearCookie(STATE_COOKIE_NAME)
+          res.status(400).json({ error: 'Missing code or state parameter' })
+          return
+        }
+
+        // Get and validate stored state
+        const stateCookie = req.cookies[STATE_COOKIE_NAME]
+        if (!stateCookie) {
+          res.status(400).json({ error: 'Missing state cookie' })
+          return
+        }
+
+        const configuration = getConfiguration()
+        let authState
+        try {
+          authState = decryptState(stateCookie, configuration.secretKey)
+          validateState(state, authState)
+        } catch (err) {
+          res.clearCookie(STATE_COOKIE_NAME)
+          console.error('OIDC state validation failed:', err)
+          res.status(400).json({
+            error: 'State validation failed',
+            message:
+              err instanceof OIDCError
+                ? err.message
+                : 'Invalid or expired state'
+          })
+          return
+        }
+
+        const oidcConfig = getOIDCConfig()
+        const metadata = await getDiscoveryDocument(oidcConfig.issuer)
+
+        // Exchange code for tokens
+        const tokens = await exchangeAuthorizationCode(
+          code,
+          oidcConfig,
+          metadata,
+          authState
+        )
+
+        // Validate ID token signature and claims (including nonce)
+        const claims = await validateIdToken(
+          tokens.idToken,
+          oidcConfig,
+          metadata,
+          authState.nonce
+        )
+
+        // Clear state cookie after successful validation
+        res.clearCookie(STATE_COOKIE_NAME)
+
+        // Extract user info from validated claims
+        const userInfo = {
+          sub: claims.sub,
+          email: claims.email,
+          name: claims.name,
+          preferredUsername: claims.preferred_username,
+          groups: claims.groups
+        }
+        debug(`OIDC: user authenticated: ${userInfo.sub}`)
+
+        // Find or create user
+        const user = await findOrCreateOIDCUser(userInfo, oidcConfig)
+        if (!user) {
+          res.status(403).json({
+            error: 'User creation denied',
+            message: 'OIDC user auto-creation is disabled'
+          })
+          return
+        }
+
+        // Issue local JWT token (same as regular login)
+        const payload = { id: user.username }
+        const theExpiration = configuration.expiration || '1h'
+        const jwtOptions = {}
+        if (theExpiration !== 'NEVER') {
+          jwtOptions.expiresIn = theExpiration
+        }
+        const token = jwt.sign(payload, configuration.secretKey, jwtOptions)
+
+        // Set cookies (same as regular login)
+        const cookieOptions = {
+          httpOnly: true,
+          maxAge: ms(
+            configuration.expiration === 'NEVER'
+              ? '10y'
+              : configuration.expiration || '1h'
+          )
+        }
+        res.cookie('JAUTHENTICATION', token, cookieOptions)
+        res.cookie(
+          BROWSER_LOGININFO_COOKIE_NAME,
+          JSON.stringify({ status: 'loggedIn', user: user.username })
+        )
+
+        // Redirect to original destination
+        res.redirect(authState.originalUrl)
+      } catch (err) {
+        console.error('OIDC callback error:', err)
+        res.status(500).json({
+          error: 'OIDC authentication failed',
+          message: err instanceof Error ? err.message : String(err)
+        })
+      }
+    })
+
+    // OIDC status endpoint - returns OIDC configuration status
+    app.get(`${skAuthPrefix}/oidc/status`, (req, res) => {
+      try {
+        const oidcConfig = getOIDCConfig()
+        res.json({
+          enabled: isOIDCEnabled(oidcConfig),
+          issuer: oidcConfig.enabled ? oidcConfig.issuer : undefined,
+          loginUrl: oidcConfig.enabled
+            ? `${skAuthPrefix}/oidc/login`
+            : undefined
+        })
+      } catch (_err) {
+        res.json({ enabled: false })
+      }
     })
     ;[
       '/restart',

--- a/test/oidc/authorization.test.ts
+++ b/test/oidc/authorization.test.ts
@@ -15,7 +15,9 @@ describe('Authorization URL', () => {
     clientSecret: 'test-secret',
     scope: 'openid email profile',
     defaultPermission: 'readonly',
-    autoCreateUsers: true
+    autoCreateUsers: true,
+    providerName: 'SSO Login',
+    autoLogin: false
   }
 
   const metadata: OIDCProviderMetadata = {

--- a/test/oidc/authorization.test.ts
+++ b/test/oidc/authorization.test.ts
@@ -1,0 +1,123 @@
+import { expect } from 'chai'
+import { buildAuthorizationUrl } from '../../src/oidc/authorization'
+import {
+  OIDCConfig,
+  OIDCAuthState,
+  OIDCProviderMetadata
+} from '../../src/oidc/types'
+import { calculateCodeChallenge } from '../../src/oidc/pkce'
+
+describe('Authorization URL', () => {
+  const config: OIDCConfig = {
+    enabled: true,
+    issuer: 'https://auth.example.com',
+    clientId: 'signalk-server',
+    clientSecret: 'test-secret',
+    scope: 'openid email profile',
+    defaultPermission: 'readonly',
+    autoCreateUsers: true
+  }
+
+  const metadata: OIDCProviderMetadata = {
+    issuer: 'https://auth.example.com',
+    authorization_endpoint: 'https://auth.example.com/authorize',
+    token_endpoint: 'https://auth.example.com/token',
+    jwks_uri: 'https://auth.example.com/.well-known/jwks.json',
+    response_types_supported: ['code'],
+    code_challenge_methods_supported: ['S256']
+  }
+
+  const authState: OIDCAuthState = {
+    state: 'test-state-value',
+    codeVerifier: 'test-code-verifier-12345678901234567890',
+    nonce: 'test-nonce-value',
+    redirectUri: 'https://signalk.local:3000/signalk/v1/auth/oidc/callback',
+    originalUrl: '/admin',
+    createdAt: Date.now()
+  }
+
+  describe('buildAuthorizationUrl', () => {
+    it('should include required OAuth parameters', () => {
+      const url = buildAuthorizationUrl(config, metadata, authState)
+      const parsed = new URL(url)
+
+      expect(parsed.origin + parsed.pathname).to.equal(
+        'https://auth.example.com/authorize'
+      )
+      expect(parsed.searchParams.get('response_type')).to.equal('code')
+      expect(parsed.searchParams.get('client_id')).to.equal('signalk-server')
+      expect(parsed.searchParams.get('redirect_uri')).to.equal(
+        'https://signalk.local:3000/signalk/v1/auth/oidc/callback'
+      )
+    })
+
+    it('should include PKCE code_challenge', () => {
+      const url = buildAuthorizationUrl(config, metadata, authState)
+      const parsed = new URL(url)
+
+      const expectedChallenge = calculateCodeChallenge(authState.codeVerifier)
+      expect(parsed.searchParams.get('code_challenge')).to.equal(
+        expectedChallenge
+      )
+      expect(parsed.searchParams.get('code_challenge_method')).to.equal('S256')
+    })
+
+    it('should include state and nonce', () => {
+      const url = buildAuthorizationUrl(config, metadata, authState)
+      const parsed = new URL(url)
+
+      expect(parsed.searchParams.get('state')).to.equal('test-state-value')
+      expect(parsed.searchParams.get('nonce')).to.equal('test-nonce-value')
+    })
+
+    it('should URL-encode parameters correctly', () => {
+      const stateWithSpecialChars: OIDCAuthState = {
+        ...authState,
+        redirectUri: 'https://signalk.local:3000/callback?foo=bar&baz=qux'
+      }
+
+      const url = buildAuthorizationUrl(config, metadata, stateWithSpecialChars)
+      const parsed = new URL(url)
+
+      // URL should be properly encoded
+      expect(parsed.searchParams.get('redirect_uri')).to.equal(
+        'https://signalk.local:3000/callback?foo=bar&baz=qux'
+      )
+    })
+
+    it('should use authorization_endpoint from discovery', () => {
+      const customMetadata: OIDCProviderMetadata = {
+        ...metadata,
+        authorization_endpoint: 'https://auth.example.com/oauth2/authorize'
+      }
+
+      const url = buildAuthorizationUrl(config, customMetadata, authState)
+      const parsed = new URL(url)
+
+      expect(parsed.origin + parsed.pathname).to.equal(
+        'https://auth.example.com/oauth2/authorize'
+      )
+    })
+
+    it('should include configured scope', () => {
+      const url = buildAuthorizationUrl(config, metadata, authState)
+      const parsed = new URL(url)
+
+      expect(parsed.searchParams.get('scope')).to.equal('openid email profile')
+    })
+
+    it('should handle custom scope', () => {
+      const customConfig: OIDCConfig = {
+        ...config,
+        scope: 'openid email profile groups'
+      }
+
+      const url = buildAuthorizationUrl(customConfig, metadata, authState)
+      const parsed = new URL(url)
+
+      expect(parsed.searchParams.get('scope')).to.equal(
+        'openid email profile groups'
+      )
+    })
+  })
+})

--- a/test/oidc/config.test.ts
+++ b/test/oidc/config.test.ts
@@ -104,6 +104,24 @@ describe('OIDC Configuration', () => {
       const config = parseEnvConfig()
       expect(config.groupsAttribute).to.equal('roles')
     })
+
+    it('should parse provider name', () => {
+      process.env.SIGNALK_OIDC_PROVIDER_NAME = 'Corporate SSO'
+      const config = parseEnvConfig()
+      expect(config.providerName).to.equal('Corporate SSO')
+    })
+
+    it('should parse auto login as true', () => {
+      process.env.SIGNALK_OIDC_AUTO_LOGIN = 'true'
+      const config = parseEnvConfig()
+      expect(config.autoLogin).to.equal(true)
+    })
+
+    it('should parse auto login as false', () => {
+      process.env.SIGNALK_OIDC_AUTO_LOGIN = 'false'
+      const config = parseEnvConfig()
+      expect(config.autoLogin).to.equal(false)
+    })
   })
 
   describe('mergeConfigs', () => {
@@ -217,6 +235,78 @@ describe('OIDC Configuration', () => {
       const result = mergeConfigs(securityJsonConfig, {})
 
       expect(result.groupsAttribute).to.equal('roles')
+    })
+
+    it('should merge provider name from security.json', () => {
+      const securityJsonConfig = {
+        enabled: true,
+        issuer: 'https://auth.example.com',
+        clientId: 'signalk',
+        clientSecret: 'secret',
+        providerName: 'Company SSO'
+      }
+
+      const result = mergeConfigs(securityJsonConfig, {})
+
+      expect(result.providerName).to.equal('Company SSO')
+    })
+
+    it('should override provider name from env over security.json', () => {
+      const securityJsonConfig = {
+        enabled: true,
+        issuer: 'https://auth.example.com',
+        clientId: 'signalk',
+        clientSecret: 'secret',
+        providerName: 'JSON Provider'
+      }
+
+      const envConfig = {
+        providerName: 'Env Provider'
+      }
+
+      const result = mergeConfigs(securityJsonConfig, envConfig)
+
+      expect(result.providerName).to.equal('Env Provider')
+    })
+
+    it('should use default provider name when not specified', () => {
+      const securityJsonConfig = {
+        enabled: true,
+        issuer: 'https://auth.example.com',
+        clientId: 'signalk',
+        clientSecret: 'secret'
+      }
+
+      const result = mergeConfigs(securityJsonConfig, {})
+
+      expect(result.providerName).to.equal('SSO Login')
+    })
+
+    it('should merge auto login from security.json', () => {
+      const securityJsonConfig = {
+        enabled: true,
+        issuer: 'https://auth.example.com',
+        clientId: 'signalk',
+        clientSecret: 'secret',
+        autoLogin: true
+      }
+
+      const result = mergeConfigs(securityJsonConfig, {})
+
+      expect(result.autoLogin).to.equal(true)
+    })
+
+    it('should default auto login to false', () => {
+      const securityJsonConfig = {
+        enabled: true,
+        issuer: 'https://auth.example.com',
+        clientId: 'signalk',
+        clientSecret: 'secret'
+      }
+
+      const result = mergeConfigs(securityJsonConfig, {})
+
+      expect(result.autoLogin).to.equal(false)
     })
   })
 

--- a/test/oidc/config.test.ts
+++ b/test/oidc/config.test.ts
@@ -1,0 +1,221 @@
+import { expect } from 'chai'
+import {
+  parseOIDCConfig,
+  isOIDCEnabled,
+  validateOIDCConfig,
+  parseEnvConfig,
+  mergeConfigs
+} from '../../src/oidc/config'
+import { OIDCError, OIDC_DEFAULTS } from '../../src/oidc/types'
+
+describe('OIDC Configuration', () => {
+  const validConfig = {
+    enabled: true,
+    issuer: 'https://auth.example.com',
+    clientId: 'signalk-server',
+    clientSecret: 'test-secret'
+  }
+
+  describe('parseEnvConfig', () => {
+    const originalEnv = process.env
+
+    beforeEach(() => {
+      process.env = { ...originalEnv }
+    })
+
+    afterEach(() => {
+      process.env = originalEnv
+    })
+
+    it('should parse environment variables correctly', () => {
+      process.env.SIGNALK_OIDC_ENABLED = 'true'
+      process.env.SIGNALK_OIDC_ISSUER = 'https://auth.example.com'
+      process.env.SIGNALK_OIDC_CLIENT_ID = 'my-client'
+      process.env.SIGNALK_OIDC_CLIENT_SECRET = 'my-secret'
+      process.env.SIGNALK_OIDC_SCOPE = 'openid email'
+      process.env.SIGNALK_OIDC_DEFAULT_PERMISSION = 'readwrite'
+
+      const config = parseEnvConfig()
+
+      expect(config.enabled).to.equal(true)
+      expect(config.issuer).to.equal('https://auth.example.com')
+      expect(config.clientId).to.equal('my-client')
+      expect(config.clientSecret).to.equal('my-secret')
+      expect(config.scope).to.equal('openid email')
+      expect(config.defaultPermission).to.equal('readwrite')
+    })
+
+    it('should return undefined for unset environment variables', () => {
+      const config = parseEnvConfig()
+
+      expect(config.enabled).to.equal(undefined)
+      expect(config.issuer).to.equal(undefined)
+      expect(config.clientId).to.equal(undefined)
+    })
+
+    it('should parse enabled as false correctly', () => {
+      process.env.SIGNALK_OIDC_ENABLED = 'false'
+      const config = parseEnvConfig()
+      expect(config.enabled).to.equal(false)
+    })
+
+    it('should parse autoCreateUsers correctly', () => {
+      process.env.SIGNALK_OIDC_AUTO_CREATE_USERS = 'false'
+      const config = parseEnvConfig()
+      expect(config.autoCreateUsers).to.equal(false)
+    })
+  })
+
+  describe('mergeConfigs', () => {
+    it('should merge security.json oidc section with defaults', () => {
+      const securityJsonConfig = {
+        enabled: true,
+        issuer: 'https://auth.example.com',
+        clientId: 'signalk',
+        clientSecret: 'secret'
+      }
+
+      const result = mergeConfigs(securityJsonConfig, {})
+
+      expect(result.enabled).to.equal(true)
+      expect(result.issuer).to.equal('https://auth.example.com')
+      expect(result.scope).to.equal(OIDC_DEFAULTS.scope)
+      expect(result.defaultPermission).to.equal(OIDC_DEFAULTS.defaultPermission)
+    })
+
+    it('should merge env vars over security.json', () => {
+      const securityJsonConfig = {
+        enabled: true,
+        issuer: 'https://auth.example.com',
+        clientId: 'signalk',
+        clientSecret: 'old-secret',
+        scope: 'openid'
+      }
+
+      const envConfig = {
+        clientSecret: 'new-secret',
+        scope: 'openid email profile groups'
+      }
+
+      const result = mergeConfigs(securityJsonConfig, envConfig)
+
+      expect(result.clientSecret).to.equal('new-secret')
+      expect(result.scope).to.equal('openid email profile groups')
+      expect(result.issuer).to.equal('https://auth.example.com')
+    })
+
+    it('should apply defaults for missing optional fields', () => {
+      const securityJsonConfig = {
+        enabled: true,
+        issuer: 'https://auth.example.com',
+        clientId: 'signalk',
+        clientSecret: 'secret'
+      }
+
+      const result = mergeConfigs(securityJsonConfig, {})
+
+      expect(result.scope).to.equal('openid email profile')
+      expect(result.defaultPermission).to.equal('readonly')
+      expect(result.autoCreateUsers).to.equal(true)
+    })
+  })
+
+  describe('validateOIDCConfig', () => {
+    it('should pass for valid complete config', () => {
+      expect(() => validateOIDCConfig(validConfig)).to.not.throw()
+    })
+
+    it('should throw for missing required fields when enabled', () => {
+      const incomplete = { enabled: true, issuer: 'https://auth.example.com' }
+      expect(() => validateOIDCConfig(incomplete)).to.throw(OIDCError)
+    })
+
+    it('should throw if issuer is not a valid URL', () => {
+      const badIssuer = { ...validConfig, issuer: 'not-a-url' }
+      expect(() => validateOIDCConfig(badIssuer)).to.throw(
+        OIDCError,
+        /valid URL/
+      )
+    })
+
+    it('should throw if scope does not contain openid', () => {
+      const badScope = { ...validConfig, scope: 'email profile' }
+      expect(() => validateOIDCConfig(badScope)).to.throw(OIDCError, /openid/)
+    })
+
+    it('should throw if defaultPermission is invalid', () => {
+      const badPermission = {
+        ...validConfig,
+        defaultPermission: 'superadmin' as 'readonly' | 'readwrite' | 'admin'
+      }
+      expect(() => validateOIDCConfig(badPermission)).to.throw(
+        OIDCError,
+        /defaultPermission/
+      )
+    })
+
+    it('should not throw when disabled even if incomplete', () => {
+      const disabled = { enabled: false }
+      expect(() => validateOIDCConfig(disabled)).to.not.throw()
+    })
+  })
+
+  describe('parseOIDCConfig', () => {
+    const originalEnv = process.env
+
+    beforeEach(() => {
+      process.env = { ...originalEnv }
+    })
+
+    afterEach(() => {
+      process.env = originalEnv
+    })
+
+    it('should parse complete config from security.json', () => {
+      const securityConfig = { oidc: validConfig }
+      const result = parseOIDCConfig(securityConfig)
+
+      expect(result.enabled).to.equal(true)
+      expect(result.issuer).to.equal('https://auth.example.com')
+      expect(result.clientId).to.equal('signalk-server')
+      expect(result.clientSecret).to.equal('test-secret')
+    })
+
+    it('should override with environment variables', () => {
+      process.env.SIGNALK_OIDC_CLIENT_SECRET = 'env-secret'
+      const securityConfig = { oidc: validConfig }
+      const result = parseOIDCConfig(securityConfig)
+
+      expect(result.clientSecret).to.equal('env-secret')
+    })
+
+    it('should return disabled config when oidc section missing', () => {
+      const result = parseOIDCConfig({})
+      expect(result.enabled).to.equal(false)
+    })
+
+    it('should validate the final config', () => {
+      const badConfig = { oidc: { enabled: true, issuer: 'bad-url' } }
+      expect(() => parseOIDCConfig(badConfig)).to.throw(OIDCError)
+    })
+  })
+
+  describe('isOIDCEnabled', () => {
+    it('should return false when not configured', () => {
+      const config = parseOIDCConfig({})
+      expect(isOIDCEnabled(config)).to.equal(false)
+    })
+
+    it('should return false when explicitly disabled', () => {
+      const config = parseOIDCConfig({
+        oidc: { ...validConfig, enabled: false }
+      })
+      expect(isOIDCEnabled(config)).to.equal(false)
+    })
+
+    it('should return true when properly configured and enabled', () => {
+      const config = parseOIDCConfig({ oidc: validConfig })
+      expect(isOIDCEnabled(config)).to.equal(true)
+    })
+  })
+})

--- a/test/oidc/discovery.test.ts
+++ b/test/oidc/discovery.test.ts
@@ -1,0 +1,225 @@
+import { expect } from 'chai'
+import {
+  fetchDiscoveryDocument,
+  getDiscoveryDocument,
+  clearDiscoveryCache,
+  setFetchFunction,
+  resetFetchFunction
+} from '../../src/oidc/discovery'
+import { OIDCError } from '../../src/oidc/types'
+
+describe('Discovery', () => {
+  const issuer = 'https://auth.example.com'
+  const discoveryDoc = {
+    issuer: 'https://auth.example.com',
+    authorization_endpoint: 'https://auth.example.com/authorize',
+    token_endpoint: 'https://auth.example.com/token',
+    userinfo_endpoint: 'https://auth.example.com/userinfo',
+    jwks_uri: 'https://auth.example.com/.well-known/jwks.json',
+    response_types_supported: ['code'],
+    code_challenge_methods_supported: ['S256']
+  }
+
+  // Helper to create a mock fetch function
+  function createMockFetch(
+    responses: Map<string, { status: number; body: unknown; error?: Error }>
+  ) {
+    return async (url: string | URL | Request): Promise<Response> => {
+      const urlStr = url.toString()
+      const response = responses.get(urlStr)
+
+      if (!response) {
+        throw new Error(`No mock response for ${urlStr}`)
+      }
+
+      if (response.error) {
+        throw response.error
+      }
+
+      return new Response(
+        typeof response.body === 'string'
+          ? response.body
+          : JSON.stringify(response.body),
+        { status: response.status }
+      )
+    }
+  }
+
+  beforeEach(() => {
+    clearDiscoveryCache()
+    resetFetchFunction()
+  })
+
+  afterEach(() => {
+    resetFetchFunction()
+  })
+
+  describe('fetchDiscoveryDocument', () => {
+    it('should fetch discovery document from issuer', async () => {
+      const responses = new Map([
+        [
+          `${issuer}/.well-known/openid-configuration`,
+          { status: 200, body: discoveryDoc }
+        ]
+      ])
+      setFetchFunction(createMockFetch(responses))
+
+      const result = await fetchDiscoveryDocument(issuer)
+
+      expect(result.issuer).to.equal(issuer)
+      expect(result.authorization_endpoint).to.equal(
+        'https://auth.example.com/authorize'
+      )
+      expect(result.token_endpoint).to.equal('https://auth.example.com/token')
+      expect(result.jwks_uri).to.equal(
+        'https://auth.example.com/.well-known/jwks.json'
+      )
+    })
+
+    it('should throw on network error', async () => {
+      const responses = new Map([
+        [
+          `${issuer}/.well-known/openid-configuration`,
+          { status: 0, body: null, error: new Error('Connection refused') }
+        ]
+      ])
+      setFetchFunction(createMockFetch(responses))
+
+      try {
+        await fetchDiscoveryDocument(issuer)
+        expect.fail('Should have thrown')
+      } catch (err) {
+        expect(err).to.be.instanceOf(OIDCError)
+        expect((err as OIDCError).code).to.equal('DISCOVERY_FAILED')
+      }
+    })
+
+    it('should throw on non-200 response', async () => {
+      const responses = new Map([
+        [
+          `${issuer}/.well-known/openid-configuration`,
+          { status: 404, body: 'Not found' }
+        ]
+      ])
+      setFetchFunction(createMockFetch(responses))
+
+      try {
+        await fetchDiscoveryDocument(issuer)
+        expect.fail('Should have thrown')
+      } catch (err) {
+        expect(err).to.be.instanceOf(OIDCError)
+        expect((err as OIDCError).code).to.equal('DISCOVERY_FAILED')
+      }
+    })
+
+    it('should throw on invalid JSON', async () => {
+      const responses = new Map([
+        [
+          `${issuer}/.well-known/openid-configuration`,
+          { status: 200, body: 'not json' }
+        ]
+      ])
+      setFetchFunction(createMockFetch(responses))
+
+      try {
+        await fetchDiscoveryDocument(issuer)
+        expect.fail('Should have thrown')
+      } catch (err) {
+        expect(err).to.be.instanceOf(OIDCError)
+        expect((err as OIDCError).code).to.equal('DISCOVERY_FAILED')
+      }
+    })
+
+    it('should throw if required fields are missing', async () => {
+      const incomplete = {
+        issuer: 'https://auth.example.com'
+        // Missing authorization_endpoint, token_endpoint, jwks_uri
+      }
+
+      const responses = new Map([
+        [
+          `${issuer}/.well-known/openid-configuration`,
+          { status: 200, body: incomplete }
+        ]
+      ])
+      setFetchFunction(createMockFetch(responses))
+
+      try {
+        await fetchDiscoveryDocument(issuer)
+        expect.fail('Should have thrown')
+      } catch (err) {
+        expect(err).to.be.instanceOf(OIDCError)
+        expect((err as OIDCError).code).to.equal('DISCOVERY_FAILED')
+      }
+    })
+  })
+
+  describe('getDiscoveryDocument (with caching)', () => {
+    it('should cache discovery document', async () => {
+      let callCount = 0
+      const mockFetch = async (): Promise<Response> => {
+        callCount++
+        return new Response(JSON.stringify(discoveryDoc), { status: 200 })
+      }
+      setFetchFunction(mockFetch)
+
+      // First call
+      const result1 = await getDiscoveryDocument(issuer)
+      expect(result1.issuer).to.equal(issuer)
+      expect(callCount).to.equal(1)
+
+      // Second call should use cache
+      const result2 = await getDiscoveryDocument(issuer)
+      expect(result2.issuer).to.equal(issuer)
+      expect(callCount).to.equal(1) // Should not have fetched again
+    })
+
+    it('should clear cache with clearDiscoveryCache', async () => {
+      let callCount = 0
+      const mockFetch = async (): Promise<Response> => {
+        callCount++
+        return new Response(JSON.stringify(discoveryDoc), { status: 200 })
+      }
+      setFetchFunction(mockFetch)
+
+      // First call
+      await getDiscoveryDocument(issuer)
+      expect(callCount).to.equal(1)
+
+      // Clear cache
+      clearDiscoveryCache()
+
+      // Second call should fetch again
+      await getDiscoveryDocument(issuer)
+      expect(callCount).to.equal(2)
+    })
+
+    it('should handle different issuers separately', async () => {
+      const issuer2 = 'https://other.example.com'
+      const discoveryDoc2 = {
+        ...discoveryDoc,
+        issuer: issuer2,
+        authorization_endpoint: 'https://other.example.com/authorize',
+        token_endpoint: 'https://other.example.com/token',
+        jwks_uri: 'https://other.example.com/jwks'
+      }
+
+      const mockFetch = async (
+        url: string | URL | Request
+      ): Promise<Response> => {
+        const urlStr = url.toString()
+        if (urlStr.includes('other.example.com')) {
+          return new Response(JSON.stringify(discoveryDoc2), { status: 200 })
+        }
+        return new Response(JSON.stringify(discoveryDoc), { status: 200 })
+      }
+      setFetchFunction(mockFetch)
+
+      const result1 = await getDiscoveryDocument(issuer)
+      const result2 = await getDiscoveryDocument(issuer2)
+
+      expect(result1.issuer).to.equal(issuer)
+      expect(result2.issuer).to.equal(issuer2)
+    })
+  })
+})

--- a/test/oidc/id-token-validation.test.ts
+++ b/test/oidc/id-token-validation.test.ts
@@ -1,0 +1,335 @@
+import { expect } from 'chai'
+import { webcrypto } from 'crypto'
+import {
+  validateIdToken,
+  fetchJwks,
+  clearJwksCache,
+  setFetchFunction as setJwksFetch,
+  resetFetchFunction as resetJwksFetch,
+  JSONWebKeySet
+} from '../../src/oidc/id-token-validation'
+import {
+  OIDCConfig,
+  OIDCProviderMetadata,
+  OIDCError
+} from '../../src/oidc/types'
+
+// Polyfill for Node 18 which doesn't have crypto as a global
+if (typeof globalThis.crypto === 'undefined') {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(globalThis as any).crypto = webcrypto
+}
+
+// Dynamic import for jose (ESM-only module)
+
+type JoseModule = typeof import('jose')
+let jose: JoseModule
+
+describe('ID Token Validation', () => {
+  // Test key pair for signing tokens
+  let privateKey: CryptoKey
+  let publicKey: CryptoKey
+  let jwks: JSONWebKeySet
+
+  const config: OIDCConfig = {
+    enabled: true,
+    issuer: 'https://auth.example.com',
+    clientId: 'signalk-server',
+    clientSecret: 'test-secret',
+    scope: 'openid email profile',
+    defaultPermission: 'readonly',
+    autoCreateUsers: true
+  }
+
+  const metadata: OIDCProviderMetadata = {
+    issuer: 'https://auth.example.com',
+    authorization_endpoint: 'https://auth.example.com/authorize',
+    token_endpoint: 'https://auth.example.com/token',
+    jwks_uri: 'https://auth.example.com/.well-known/jwks.json',
+    response_types_supported: ['code'],
+    code_challenge_methods_supported: ['S256']
+  }
+
+  before(async () => {
+    // Dynamically import jose
+    jose = await import('jose')
+
+    // Generate a test key pair
+    const keyPair = await jose.generateKeyPair('RS256')
+    privateKey = keyPair.privateKey
+    publicKey = keyPair.publicKey
+
+    // Export public key as JWK for JWKS endpoint
+    const publicJwk = await jose.exportJWK(publicKey)
+    publicJwk.kid = 'test-key-1'
+    publicJwk.alg = 'RS256'
+    publicJwk.use = 'sig'
+    // Cast to our JSONWebKeySet type - kty is guaranteed to exist for exported RSA keys
+    jwks = { keys: [publicJwk as JSONWebKeySet['keys'][0]] }
+  })
+
+  beforeEach(() => {
+    clearJwksCache()
+    resetJwksFetch()
+  })
+
+  afterEach(() => {
+    resetJwksFetch()
+  })
+
+  // Helper to create a signed ID token
+  async function createIdToken(
+    claims: Record<string, unknown>
+  ): Promise<string> {
+    const now = Math.floor(Date.now() / 1000)
+    const defaultClaims = {
+      iss: 'https://auth.example.com',
+      sub: 'user-123',
+      aud: 'signalk-server',
+      exp: now + 3600,
+      iat: now,
+      nonce: 'test-nonce'
+    }
+    return new jose.SignJWT({ ...defaultClaims, ...claims })
+      .setProtectedHeader({ alg: 'RS256', kid: 'test-key-1' })
+      .sign(privateKey)
+  }
+
+  // Helper to setup JWKS mock
+  function setupJwksMock() {
+    const mockFetch = async (
+      url: string | URL | Request
+    ): Promise<Response> => {
+      const urlStr = url.toString()
+      if (urlStr === 'https://auth.example.com/.well-known/jwks.json') {
+        return new Response(JSON.stringify(jwks), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+      }
+      throw new Error(`Unexpected URL: ${urlStr}`)
+    }
+    setJwksFetch(mockFetch)
+  }
+
+  describe('fetchJwks', () => {
+    it('should fetch JWKS from provider', async () => {
+      setupJwksMock()
+      const result = await fetchJwks(metadata)
+      expect(result.keys).to.have.length(1)
+      expect(result.keys[0].kid).to.equal('test-key-1')
+    })
+
+    it('should cache JWKS', async () => {
+      let callCount = 0
+      const mockFetch = async (): Promise<Response> => {
+        callCount++
+        return new Response(JSON.stringify(jwks), { status: 200 })
+      }
+      setJwksFetch(mockFetch)
+
+      await fetchJwks(metadata)
+      await fetchJwks(metadata)
+
+      expect(callCount).to.equal(1)
+    })
+
+    it('should throw on network error', async () => {
+      const mockFetch = async (): Promise<Response> => {
+        throw new Error('Network error')
+      }
+      setJwksFetch(mockFetch)
+
+      try {
+        await fetchJwks(metadata)
+        expect.fail('Should have thrown')
+      } catch (err) {
+        expect(err).to.be.instanceOf(OIDCError)
+        expect((err as OIDCError).code).to.equal('DISCOVERY_FAILED')
+      }
+    })
+  })
+
+  describe('validateIdToken', () => {
+    it('should validate a properly signed token', async () => {
+      setupJwksMock()
+      const idToken = await createIdToken({})
+      const claims = await validateIdToken(
+        idToken,
+        config,
+        metadata,
+        'test-nonce'
+      )
+
+      expect(claims.sub).to.equal('user-123')
+      expect(claims.iss).to.equal('https://auth.example.com')
+      expect(claims.aud).to.equal('signalk-server')
+    })
+
+    it('should reject token with wrong issuer', async () => {
+      setupJwksMock()
+      const idToken = await createIdToken({ iss: 'https://wrong-issuer.com' })
+
+      try {
+        await validateIdToken(idToken, config, metadata, 'test-nonce')
+        expect.fail('Should have thrown')
+      } catch (err) {
+        expect(err).to.be.instanceOf(OIDCError)
+        expect((err as OIDCError).code).to.equal('INVALID_TOKEN')
+        expect((err as OIDCError).message).to.include('issuer')
+      }
+    })
+
+    it('should reject token with wrong audience', async () => {
+      setupJwksMock()
+      const idToken = await createIdToken({ aud: 'wrong-client' })
+
+      try {
+        await validateIdToken(idToken, config, metadata, 'test-nonce')
+        expect.fail('Should have thrown')
+      } catch (err) {
+        expect(err).to.be.instanceOf(OIDCError)
+        expect((err as OIDCError).code).to.equal('INVALID_TOKEN')
+        expect((err as OIDCError).message).to.include('audience')
+      }
+    })
+
+    it('should reject expired token', async () => {
+      setupJwksMock()
+      const now = Math.floor(Date.now() / 1000)
+      const idToken = await createIdToken({
+        exp: now - 3600, // expired 1 hour ago
+        iat: now - 7200
+      })
+
+      try {
+        await validateIdToken(idToken, config, metadata, 'test-nonce')
+        expect.fail('Should have thrown')
+      } catch (err) {
+        expect(err).to.be.instanceOf(OIDCError)
+        expect((err as OIDCError).code).to.equal('INVALID_TOKEN')
+        expect((err as OIDCError).message).to.include('expired')
+      }
+    })
+
+    it('should reject token with wrong nonce', async () => {
+      setupJwksMock()
+      const idToken = await createIdToken({ nonce: 'wrong-nonce' })
+
+      try {
+        await validateIdToken(idToken, config, metadata, 'expected-nonce')
+        expect.fail('Should have thrown')
+      } catch (err) {
+        expect(err).to.be.instanceOf(OIDCError)
+        expect((err as OIDCError).code).to.equal('INVALID_TOKEN')
+        expect((err as OIDCError).message).to.include('nonce')
+      }
+    })
+
+    it('should reject token with missing nonce when expected', async () => {
+      setupJwksMock()
+      const now = Math.floor(Date.now() / 1000)
+      // Create token without nonce claim
+      const idToken = await new jose.SignJWT({
+        iss: 'https://auth.example.com',
+        sub: 'user-123',
+        aud: 'signalk-server',
+        exp: now + 3600,
+        iat: now
+        // no nonce
+      })
+        .setProtectedHeader({ alg: 'RS256', kid: 'test-key-1' })
+        .sign(privateKey)
+
+      try {
+        await validateIdToken(idToken, config, metadata, 'expected-nonce')
+        expect.fail('Should have thrown')
+      } catch (err) {
+        expect(err).to.be.instanceOf(OIDCError)
+        expect((err as OIDCError).code).to.equal('INVALID_TOKEN')
+        expect((err as OIDCError).message).to.include('nonce')
+      }
+    })
+
+    it('should accept token with audience as array containing client_id', async () => {
+      setupJwksMock()
+      const idToken = await createIdToken({
+        aud: ['other-client', 'signalk-server', 'another-client']
+      })
+
+      const claims = await validateIdToken(
+        idToken,
+        config,
+        metadata,
+        'test-nonce'
+      )
+      expect(claims.sub).to.equal('user-123')
+    })
+
+    it('should reject token with invalid signature', async () => {
+      setupJwksMock()
+      // Create a token signed with a different key
+      const differentKey = await jose.generateKeyPair('RS256')
+      const now = Math.floor(Date.now() / 1000)
+      const idToken = await new jose.SignJWT({
+        iss: 'https://auth.example.com',
+        sub: 'user-123',
+        aud: 'signalk-server',
+        exp: now + 3600,
+        iat: now,
+        nonce: 'test-nonce'
+      })
+        .setProtectedHeader({ alg: 'RS256', kid: 'test-key-1' })
+        .sign(differentKey.privateKey)
+
+      try {
+        await validateIdToken(idToken, config, metadata, 'test-nonce')
+        expect.fail('Should have thrown')
+      } catch (err) {
+        expect(err).to.be.instanceOf(OIDCError)
+        expect((err as OIDCError).code).to.equal('INVALID_TOKEN')
+      }
+    })
+
+    it('should allow 5 minute clock skew for expiration', async () => {
+      setupJwksMock()
+      const now = Math.floor(Date.now() / 1000)
+      // Token expired 2 minutes ago (within 5 min skew)
+      const idToken = await createIdToken({
+        exp: now - 120,
+        iat: now - 3720
+      })
+
+      // Should not throw due to clock skew tolerance
+      const claims = await validateIdToken(
+        idToken,
+        config,
+        metadata,
+        'test-nonce'
+      )
+      expect(claims.sub).to.equal('user-123')
+    })
+
+    it('should extract all standard claims', async () => {
+      setupJwksMock()
+      const idToken = await createIdToken({
+        email: 'user@example.com',
+        name: 'Test User',
+        preferred_username: 'testuser',
+        groups: ['admin', 'users']
+      })
+
+      const claims = await validateIdToken(
+        idToken,
+        config,
+        metadata,
+        'test-nonce'
+      )
+
+      expect(claims.email).to.equal('user@example.com')
+      expect(claims.name).to.equal('Test User')
+      expect(claims.preferred_username).to.equal('testuser')
+      expect(claims.groups).to.deep.equal(['admin', 'users'])
+    })
+  })
+})

--- a/test/oidc/id-token-validation.test.ts
+++ b/test/oidc/id-token-validation.test.ts
@@ -38,7 +38,9 @@ describe('ID Token Validation', () => {
     clientSecret: 'test-secret',
     scope: 'openid email profile',
     defaultPermission: 'readonly',
-    autoCreateUsers: true
+    autoCreateUsers: true,
+    providerName: 'SSO Login',
+    autoLogin: false
   }
 
   const metadata: OIDCProviderMetadata = {
@@ -330,143 +332,6 @@ describe('ID Token Validation', () => {
       expect(claims.name).to.equal('Test User')
       expect(claims.preferred_username).to.equal('testuser')
       expect(claims.groups).to.deep.equal(['admin', 'users'])
-    })
-  })
-
-  describe('JWKS key rotation handling', () => {
-    it('should retry with fresh JWKS when signature verification fails due to key rotation', async () => {
-      // Generate a new key pair (simulating key rotation)
-      const newKeyPair = await jose.generateKeyPair('RS256')
-      const newPublicJwk = await jose.exportJWK(newKeyPair.publicKey)
-      newPublicJwk.kid = 'new-key-1'
-      newPublicJwk.alg = 'RS256'
-      newPublicJwk.use = 'sig'
-      const newJwks = { keys: [newPublicJwk as JSONWebKeySet['keys'][0]] }
-
-      // Create token signed with the NEW key
-      const now = Math.floor(Date.now() / 1000)
-      const idToken = await new jose.SignJWT({
-        iss: 'https://auth.example.com',
-        sub: 'user-123',
-        aud: 'signalk-server',
-        exp: now + 3600,
-        iat: now,
-        nonce: 'test-nonce'
-      })
-        .setProtectedHeader({ alg: 'RS256', kid: 'new-key-1' })
-        .sign(newKeyPair.privateKey)
-
-      // First call returns old JWKS (wrong key), second call returns new JWKS
-      let fetchCount = 0
-      const mockFetch = async (): Promise<Response> => {
-        fetchCount++
-        if (fetchCount === 1) {
-          // First fetch: return old JWKS (will fail signature verification)
-          return new Response(JSON.stringify(jwks), { status: 200 })
-        }
-        // Second fetch: return new JWKS (will succeed)
-        return new Response(JSON.stringify(newJwks), { status: 200 })
-      }
-      setJwksFetch(mockFetch)
-
-      // Should succeed after retry
-      const claims = await validateIdToken(
-        idToken,
-        config,
-        metadata,
-        'test-nonce'
-      )
-
-      expect(claims.sub).to.equal('user-123')
-      expect(fetchCount).to.equal(2) // Confirms retry happened
-    })
-
-    it('should not retry for non-signature errors like expired token', async () => {
-      let fetchCount = 0
-      const mockFetch = async (): Promise<Response> => {
-        fetchCount++
-        return new Response(JSON.stringify(jwks), { status: 200 })
-      }
-      setJwksFetch(mockFetch)
-
-      // Create an expired token (signed with correct key)
-      const now = Math.floor(Date.now() / 1000)
-      const idToken = await createIdToken({
-        exp: now - 3600, // expired 1 hour ago (outside clock skew tolerance)
-        iat: now - 7200
-      })
-
-      try {
-        await validateIdToken(idToken, config, metadata, 'test-nonce')
-        expect.fail('Should have thrown')
-      } catch (err) {
-        expect(err).to.be.instanceOf(OIDCError)
-        expect((err as OIDCError).code).to.equal('INVALID_TOKEN')
-        expect((err as OIDCError).message).to.include('expired')
-      }
-
-      // Should only fetch once - no retry for expiration errors
-      expect(fetchCount).to.equal(1)
-    })
-
-    it('should not retry for issuer mismatch errors', async () => {
-      let fetchCount = 0
-      const mockFetch = async (): Promise<Response> => {
-        fetchCount++
-        return new Response(JSON.stringify(jwks), { status: 200 })
-      }
-      setJwksFetch(mockFetch)
-
-      const idToken = await createIdToken({ iss: 'https://wrong-issuer.com' })
-
-      try {
-        await validateIdToken(idToken, config, metadata, 'test-nonce')
-        expect.fail('Should have thrown')
-      } catch (err) {
-        expect(err).to.be.instanceOf(OIDCError)
-        expect((err as OIDCError).code).to.equal('INVALID_TOKEN')
-        expect((err as OIDCError).message).to.include('issuer')
-      }
-
-      // Should only fetch once - no retry for issuer errors
-      expect(fetchCount).to.equal(1)
-    })
-
-    it('should fail after retry if new JWKS also does not contain valid key', async () => {
-      // Generate a completely different key (not in any JWKS)
-      const unknownKeyPair = await jose.generateKeyPair('RS256')
-
-      // Create token signed with the unknown key
-      const now = Math.floor(Date.now() / 1000)
-      const idToken = await new jose.SignJWT({
-        iss: 'https://auth.example.com',
-        sub: 'user-123',
-        aud: 'signalk-server',
-        exp: now + 3600,
-        iat: now,
-        nonce: 'test-nonce'
-      })
-        .setProtectedHeader({ alg: 'RS256', kid: 'unknown-key' })
-        .sign(unknownKeyPair.privateKey)
-
-      // Always return the same JWKS (which doesn't have the signing key)
-      let fetchCount = 0
-      const mockFetch = async (): Promise<Response> => {
-        fetchCount++
-        return new Response(JSON.stringify(jwks), { status: 200 })
-      }
-      setJwksFetch(mockFetch)
-
-      try {
-        await validateIdToken(idToken, config, metadata, 'test-nonce')
-        expect.fail('Should have thrown')
-      } catch (err) {
-        expect(err).to.be.instanceOf(OIDCError)
-        expect((err as OIDCError).code).to.equal('INVALID_TOKEN')
-      }
-
-      // Should have retried once
-      expect(fetchCount).to.equal(2)
     })
   })
 })

--- a/test/oidc/integration.test.ts
+++ b/test/oidc/integration.test.ts
@@ -61,7 +61,9 @@ describe('OIDC Integration', () => {
         clientSecret: 'test-secret',
         scope: 'openid email profile',
         defaultPermission: 'readonly' as const,
-        autoCreateUsers: true
+        autoCreateUsers: true,
+        providerName: 'SSO Login',
+        autoLogin: false
       }
 
       const metadata = {

--- a/test/oidc/integration.test.ts
+++ b/test/oidc/integration.test.ts
@@ -1,0 +1,135 @@
+import { expect } from 'chai'
+import {
+  isOIDCEnabled,
+  parseOIDCConfig,
+  createAuthState,
+  buildAuthorizationUrl,
+  calculateCodeChallenge,
+  encryptState,
+  decryptState
+} from '../../src/oidc/index'
+
+// Test OIDC integration with the server
+// These tests verify the OIDC endpoints are properly set up
+
+describe('OIDC Integration', () => {
+  describe('OIDC Status Endpoint', () => {
+    it('should return disabled when OIDC is not configured', function () {
+      const config = parseOIDCConfig({})
+      expect(isOIDCEnabled(config)).to.equal(false)
+    })
+
+    it('should return enabled when OIDC is properly configured', function () {
+      const config = parseOIDCConfig({
+        oidc: {
+          enabled: true,
+          issuer: 'https://auth.example.com',
+          clientId: 'test-client',
+          clientSecret: 'test-secret'
+        }
+      })
+      expect(isOIDCEnabled(config)).to.equal(true)
+      expect(config.issuer).to.equal('https://auth.example.com')
+      expect(config.scope).to.equal('openid email profile')
+      expect(config.defaultPermission).to.equal('readonly')
+    })
+  })
+
+  describe('OIDC Login Flow', () => {
+    it('should create auth state with all required fields', function () {
+      const authState = createAuthState(
+        'https://signalk.local:3000/callback',
+        '/admin'
+      )
+
+      expect(authState.state).to.be.a('string')
+      expect(authState.state.length).to.be.at.least(32)
+      expect(authState.codeVerifier).to.be.a('string')
+      expect(authState.codeVerifier.length).to.be.at.least(43)
+      expect(authState.nonce).to.be.a('string')
+      expect(authState.redirectUri).to.equal(
+        'https://signalk.local:3000/callback'
+      )
+      expect(authState.originalUrl).to.equal('/admin')
+    })
+
+    it('should build authorization URL with PKCE', function () {
+      const config = {
+        enabled: true,
+        issuer: 'https://auth.example.com',
+        clientId: 'signalk-server',
+        clientSecret: 'test-secret',
+        scope: 'openid email profile',
+        defaultPermission: 'readonly' as const,
+        autoCreateUsers: true
+      }
+
+      const metadata = {
+        issuer: 'https://auth.example.com',
+        authorization_endpoint: 'https://auth.example.com/authorize',
+        token_endpoint: 'https://auth.example.com/token',
+        jwks_uri: 'https://auth.example.com/.well-known/jwks.json',
+        response_types_supported: ['code']
+      }
+
+      const authState = createAuthState(
+        'https://signalk.local:3000/callback',
+        '/'
+      )
+
+      const authUrl = buildAuthorizationUrl(config, metadata, authState)
+      const parsed = new URL(authUrl)
+
+      expect(parsed.origin).to.equal('https://auth.example.com')
+      expect(parsed.pathname).to.equal('/authorize')
+      expect(parsed.searchParams.get('response_type')).to.equal('code')
+      expect(parsed.searchParams.get('client_id')).to.equal('signalk-server')
+      expect(parsed.searchParams.get('state')).to.equal(authState.state)
+      expect(parsed.searchParams.get('nonce')).to.equal(authState.nonce)
+      expect(parsed.searchParams.get('code_challenge_method')).to.equal('S256')
+
+      // Verify PKCE challenge is correct
+      const expectedChallenge = calculateCodeChallenge(authState.codeVerifier)
+      expect(parsed.searchParams.get('code_challenge')).to.equal(
+        expectedChallenge
+      )
+    })
+
+    it('should encrypt and decrypt auth state', function () {
+      const secretKey = '0'.repeat(64) // 256-bit hex key
+      const authState = createAuthState(
+        'https://signalk.local:3000/callback',
+        '/admin'
+      )
+
+      const encrypted = encryptState(authState, secretKey)
+      expect(encrypted).to.be.a('string')
+      expect(encrypted).to.not.include(authState.state) // Should be encrypted
+
+      const decrypted = decryptState(encrypted, secretKey)
+      expect(decrypted.state).to.equal(authState.state)
+      expect(decrypted.codeVerifier).to.equal(authState.codeVerifier)
+      expect(decrypted.nonce).to.equal(authState.nonce)
+      expect(decrypted.redirectUri).to.equal(authState.redirectUri)
+      expect(decrypted.originalUrl).to.equal(authState.originalUrl)
+    })
+  })
+
+  describe('Security Types', () => {
+    it('should have OIDCUserIdentifier in User interface', function () {
+      // This test verifies the TypeScript types are correctly set up
+      // by creating a user object with OIDC fields
+      const user = {
+        username: 'john@example.com',
+        type: 'readwrite',
+        oidc: {
+          sub: 'auth0|12345',
+          issuer: 'https://auth.example.com'
+        }
+      }
+
+      expect(user.oidc.sub).to.equal('auth0|12345')
+      expect(user.oidc.issuer).to.equal('https://auth.example.com')
+    })
+  })
+})

--- a/test/oidc/oidc-auth.test.ts
+++ b/test/oidc/oidc-auth.test.ts
@@ -56,7 +56,9 @@ describe('OIDC Auth Routes', () => {
     clientSecret: 'test-secret',
     scope: 'openid email profile',
     defaultPermission: 'readonly',
-    autoCreateUsers: true
+    autoCreateUsers: true,
+    providerName: 'Test SSO',
+    autoLogin: false
   }
 
   // Track calls to dependency functions

--- a/test/oidc/oidc-auth.test.ts
+++ b/test/oidc/oidc-auth.test.ts
@@ -1,0 +1,386 @@
+import { expect } from 'chai'
+import { Request, Response as ExpressResponse, Application } from 'express'
+import {
+  registerOIDCRoutes,
+  OIDCAuthDependencies
+} from '../../src/oidc/oidc-auth'
+import {
+  setFetchFunction as setDiscoveryFetch,
+  resetFetchFunction as resetDiscoveryFetch,
+  clearDiscoveryCache
+} from '../../src/oidc/discovery'
+import { OIDCConfig } from '../../src/oidc/types'
+import { SecurityConfig } from '../../src/security'
+
+describe('OIDC Auth Routes', () => {
+  // Mock Express app that captures registered routes
+  interface RegisteredRoute {
+    method: string
+    path: string
+    handler: (req: Request, res: ExpressResponse) => Promise<void> | void
+  }
+  const registeredRoutes: RegisteredRoute[] = []
+
+  const mockApp = {
+    get: (
+      path: string,
+      handler: (req: Request, res: ExpressResponse) => void
+    ) => {
+      registeredRoutes.push({ method: 'get', path, handler })
+    },
+    post: (
+      path: string,
+      handler: (req: Request, res: ExpressResponse) => void
+    ) => {
+      registeredRoutes.push({ method: 'post', path, handler })
+    }
+  } as unknown as Application
+
+  // Mock security config
+  const mockSecurityConfig: SecurityConfig = {
+    users: [],
+    devices: [],
+    secretKey: '0'.repeat(64),
+    expiration: '1h',
+    immutableConfig: false,
+    allow_readonly: true,
+    allowNewUserRegistration: false,
+    allowDeviceAccessRequests: false
+  }
+
+  // Mock OIDC config
+  const mockOIDCConfig: OIDCConfig = {
+    enabled: true,
+    issuer: 'https://auth.example.com',
+    clientId: 'signalk-server',
+    clientSecret: 'test-secret',
+    scope: 'openid email profile',
+    defaultPermission: 'readonly',
+    autoCreateUsers: true
+  }
+
+  // Track calls to dependency functions
+  let clearCookieCalled = false
+
+  const mockDeps: OIDCAuthDependencies = {
+    getConfiguration: () => mockSecurityConfig,
+    getOIDCConfig: () => mockOIDCConfig,
+    setSessionCookie: () => {},
+    clearSessionCookie: () => {
+      clearCookieCalled = true
+    },
+    generateJWT: (userId: string) => `mock-jwt-for-${userId}`,
+    saveConfig: (_config, callback) => callback(null)
+  }
+
+  // Helper to create mock request
+  function createMockRequest(overrides: Partial<Request> = {}): Request {
+    return {
+      query: {},
+      cookies: {},
+      secure: false,
+      get: (header: string) => {
+        if (header === 'host') return 'signalk.local:3000'
+        return undefined
+      },
+      headers: {},
+      ...overrides
+    } as unknown as Request
+  }
+
+  // Helper to create mock response
+  interface MockResponse {
+    redirectUrl: string | null
+    jsonData: unknown
+    statusCode: number
+    redirect: (url: string) => void
+    json: (data: unknown) => MockResponse
+    status: (code: number) => MockResponse
+    clearCookie: () => void
+  }
+
+  function createMockResponse(): MockResponse {
+    const res: MockResponse = {
+      redirectUrl: null,
+      jsonData: null,
+      statusCode: 200,
+      redirect: function (url: string) {
+        this.redirectUrl = url
+      },
+      json: function (data: unknown) {
+        this.jsonData = data
+        return this
+      },
+      status: function (code: number) {
+        this.statusCode = code
+        return this
+      },
+      clearCookie: () => {}
+    }
+    return res
+  }
+
+  // Helper to find a registered route handler
+  function findRoute(
+    method: string,
+    path: string
+  ):
+    | ((req: Request, res: ExpressResponse) => Promise<void> | void)
+    | undefined {
+    const route = registeredRoutes.find(
+      (r) => r.method === method && r.path === path
+    )
+    return route?.handler
+  }
+
+  beforeEach(() => {
+    registeredRoutes.length = 0
+    clearCookieCalled = false
+    clearDiscoveryCache()
+    resetDiscoveryFetch()
+  })
+
+  afterEach(() => {
+    resetDiscoveryFetch()
+  })
+
+  describe('registerOIDCRoutes', () => {
+    it('should register all OIDC routes', () => {
+      registerOIDCRoutes(mockApp, mockDeps)
+
+      const paths = registeredRoutes.map((r) => r.path)
+      expect(paths).to.include('/signalk/v1/auth/oidc/login')
+      expect(paths).to.include('/signalk/v1/auth/oidc/callback')
+      expect(paths).to.include('/signalk/v1/auth/oidc/status')
+      expect(paths).to.include('/signalk/v1/auth/oidc/logout')
+    })
+  })
+
+  describe('OIDC logout endpoint', () => {
+    beforeEach(() => {
+      registerOIDCRoutes(mockApp, mockDeps)
+    })
+
+    it('should clear session cookies on logout', async () => {
+      // Mock discovery to return metadata without end_session_endpoint
+      const mockFetch = async (): Promise<Response> => {
+        return new Response(
+          JSON.stringify({
+            issuer: 'https://auth.example.com',
+            authorization_endpoint: 'https://auth.example.com/authorize',
+            token_endpoint: 'https://auth.example.com/token',
+            jwks_uri: 'https://auth.example.com/.well-known/jwks.json',
+            response_types_supported: ['code']
+            // no end_session_endpoint
+          }),
+          { status: 200 }
+        )
+      }
+      setDiscoveryFetch(mockFetch)
+
+      const handler = findRoute('get', '/signalk/v1/auth/oidc/logout')
+      expect(handler).to.not.equal(undefined)
+
+      const req = createMockRequest()
+      const res = createMockResponse()
+
+      await handler!(req, res as unknown as ExpressResponse)
+
+      expect(clearCookieCalled).to.equal(true)
+    })
+
+    it('should redirect to / by default when no redirect param', async () => {
+      // Mock discovery without end_session_endpoint
+      const mockFetch = async (): Promise<Response> => {
+        return new Response(
+          JSON.stringify({
+            issuer: 'https://auth.example.com',
+            authorization_endpoint: 'https://auth.example.com/authorize',
+            token_endpoint: 'https://auth.example.com/token',
+            jwks_uri: 'https://auth.example.com/.well-known/jwks.json',
+            response_types_supported: ['code']
+          }),
+          { status: 200 }
+        )
+      }
+      setDiscoveryFetch(mockFetch)
+
+      const handler = findRoute('get', '/signalk/v1/auth/oidc/logout')
+      const req = createMockRequest()
+      const res = createMockResponse()
+
+      await handler!(req, res as unknown as ExpressResponse)
+
+      expect(res.redirectUrl).to.equal('/')
+    })
+
+    it('should redirect to specified relative path', async () => {
+      const mockFetch = async (): Promise<Response> => {
+        return new Response(
+          JSON.stringify({
+            issuer: 'https://auth.example.com',
+            authorization_endpoint: 'https://auth.example.com/authorize',
+            token_endpoint: 'https://auth.example.com/token',
+            jwks_uri: 'https://auth.example.com/.well-known/jwks.json',
+            response_types_supported: ['code']
+          }),
+          { status: 200 }
+        )
+      }
+      setDiscoveryFetch(mockFetch)
+
+      const handler = findRoute('get', '/signalk/v1/auth/oidc/logout')
+      const req = createMockRequest({ query: { redirect: '/admin' } })
+      const res = createMockResponse()
+
+      await handler!(req, res as unknown as ExpressResponse)
+
+      expect(res.redirectUrl).to.equal('/admin')
+    })
+
+    it('should reject absolute URLs in redirect param (open redirect prevention)', async () => {
+      const mockFetch = async (): Promise<Response> => {
+        return new Response(
+          JSON.stringify({
+            issuer: 'https://auth.example.com',
+            authorization_endpoint: 'https://auth.example.com/authorize',
+            token_endpoint: 'https://auth.example.com/token',
+            jwks_uri: 'https://auth.example.com/.well-known/jwks.json',
+            response_types_supported: ['code']
+          }),
+          { status: 200 }
+        )
+      }
+      setDiscoveryFetch(mockFetch)
+
+      const handler = findRoute('get', '/signalk/v1/auth/oidc/logout')
+      const req = createMockRequest({
+        query: { redirect: 'https://evil.com/phish' }
+      })
+      const res = createMockResponse()
+
+      await handler!(req, res as unknown as ExpressResponse)
+
+      // Should redirect to / instead of the malicious URL
+      expect(res.redirectUrl).to.equal('/')
+    })
+
+    it('should reject protocol-relative URLs in redirect param', async () => {
+      const mockFetch = async (): Promise<Response> => {
+        return new Response(
+          JSON.stringify({
+            issuer: 'https://auth.example.com',
+            authorization_endpoint: 'https://auth.example.com/authorize',
+            token_endpoint: 'https://auth.example.com/token',
+            jwks_uri: 'https://auth.example.com/.well-known/jwks.json',
+            response_types_supported: ['code']
+          }),
+          { status: 200 }
+        )
+      }
+      setDiscoveryFetch(mockFetch)
+
+      const handler = findRoute('get', '/signalk/v1/auth/oidc/logout')
+      const req = createMockRequest({ query: { redirect: '//evil.com/phish' } })
+      const res = createMockResponse()
+
+      await handler!(req, res as unknown as ExpressResponse)
+
+      expect(res.redirectUrl).to.equal('/')
+    })
+
+    it('should redirect to OIDC provider logout when end_session_endpoint is available', async () => {
+      // Mock discovery WITH end_session_endpoint
+      const mockFetch = async (): Promise<Response> => {
+        return new Response(
+          JSON.stringify({
+            issuer: 'https://auth.example.com',
+            authorization_endpoint: 'https://auth.example.com/authorize',
+            token_endpoint: 'https://auth.example.com/token',
+            jwks_uri: 'https://auth.example.com/.well-known/jwks.json',
+            response_types_supported: ['code'],
+            end_session_endpoint: 'https://auth.example.com/logout'
+          }),
+          { status: 200 }
+        )
+      }
+      setDiscoveryFetch(mockFetch)
+
+      const handler = findRoute('get', '/signalk/v1/auth/oidc/logout')
+      const req = createMockRequest()
+      const res = createMockResponse()
+
+      await handler!(req, res as unknown as ExpressResponse)
+
+      expect(clearCookieCalled).to.equal(true)
+      expect(res.redirectUrl).to.include('https://auth.example.com/logout')
+      expect(res.redirectUrl).to.include('post_logout_redirect_uri=')
+    })
+
+    it('should include correct post_logout_redirect_uri in provider logout URL', async () => {
+      const mockFetch = async (): Promise<Response> => {
+        return new Response(
+          JSON.stringify({
+            issuer: 'https://auth.example.com',
+            authorization_endpoint: 'https://auth.example.com/authorize',
+            token_endpoint: 'https://auth.example.com/token',
+            jwks_uri: 'https://auth.example.com/.well-known/jwks.json',
+            response_types_supported: ['code'],
+            end_session_endpoint: 'https://auth.example.com/logout'
+          }),
+          { status: 200 }
+        )
+      }
+      setDiscoveryFetch(mockFetch)
+
+      const handler = findRoute('get', '/signalk/v1/auth/oidc/logout')
+      const req = createMockRequest({ query: { redirect: '/dashboard' } })
+      const res = createMockResponse()
+
+      await handler!(req, res as unknown as ExpressResponse)
+
+      const logoutUrl = new URL(res.redirectUrl!)
+      const postLogoutUri = logoutUrl.searchParams.get(
+        'post_logout_redirect_uri'
+      )
+      expect(postLogoutUri).to.equal('http://signalk.local:3000/dashboard')
+    })
+
+    it('should fall back to local redirect when discovery fails', async () => {
+      const mockFetch = async (): Promise<Response> => {
+        throw new Error('Network error')
+      }
+      setDiscoveryFetch(mockFetch)
+
+      const handler = findRoute('get', '/signalk/v1/auth/oidc/logout')
+      const req = createMockRequest({ query: { redirect: '/settings' } })
+      const res = createMockResponse()
+
+      await handler!(req, res as unknown as ExpressResponse)
+
+      expect(clearCookieCalled).to.equal(true)
+      expect(res.redirectUrl).to.equal('/settings')
+    })
+
+    it('should redirect locally when OIDC is disabled', async () => {
+      // Create deps with OIDC disabled
+      const disabledDeps: OIDCAuthDependencies = {
+        ...mockDeps,
+        getOIDCConfig: () => ({ ...mockOIDCConfig, enabled: false })
+      }
+
+      // Re-register routes with disabled OIDC
+      registeredRoutes.length = 0
+      registerOIDCRoutes(mockApp, disabledDeps)
+
+      const handler = findRoute('get', '/signalk/v1/auth/oidc/logout')
+      const req = createMockRequest()
+      const res = createMockResponse()
+
+      await handler!(req, res as unknown as ExpressResponse)
+
+      expect(clearCookieCalled).to.equal(true)
+      expect(res.redirectUrl).to.equal('/')
+    })
+  })
+})

--- a/test/oidc/permission-mapping.test.ts
+++ b/test/oidc/permission-mapping.test.ts
@@ -11,7 +11,9 @@ describe('OIDC Permission Mapping', () => {
     clientSecret: 'test-secret',
     scope: 'openid email profile groups',
     defaultPermission: 'readonly',
-    autoCreateUsers: true
+    autoCreateUsers: true,
+    providerName: 'SSO Login',
+    autoLogin: false
   }
 
   describe('mapGroupsToPermission', () => {

--- a/test/oidc/permission-mapping.test.ts
+++ b/test/oidc/permission-mapping.test.ts
@@ -1,0 +1,199 @@
+import { expect } from 'chai'
+
+import { mapGroupsToPermission } from '../../src/oidc/permission-mapping'
+import type { OIDCConfig } from '../../src/oidc/types'
+
+describe('OIDC Permission Mapping', () => {
+  const baseConfig: OIDCConfig = {
+    enabled: true,
+    issuer: 'https://auth.example.com',
+    clientId: 'signalk-server',
+    clientSecret: 'test-secret',
+    scope: 'openid email profile groups',
+    defaultPermission: 'readonly',
+    autoCreateUsers: true
+  }
+
+  describe('mapGroupsToPermission', () => {
+    describe('with no group configuration', () => {
+      it('should return defaultPermission when no groups configured', () => {
+        const config: OIDCConfig = { ...baseConfig }
+        const result = mapGroupsToPermission(['users', 'viewers'], config)
+        expect(result).to.equal('readonly')
+      })
+
+      it('should return defaultPermission when user has no groups', () => {
+        const config: OIDCConfig = { ...baseConfig }
+        const result = mapGroupsToPermission([], config)
+        expect(result).to.equal('readonly')
+      })
+
+      it('should return defaultPermission when user groups is undefined', () => {
+        const config: OIDCConfig = { ...baseConfig }
+        const result = mapGroupsToPermission(undefined, config)
+        expect(result).to.equal('readonly')
+      })
+    })
+
+    describe('with admin groups configured', () => {
+      it('should return admin when user is in admin group', () => {
+        const config: OIDCConfig = {
+          ...baseConfig,
+          adminGroups: ['admins', 'sk-admin']
+        }
+        const result = mapGroupsToPermission(['users', 'admins'], config)
+        expect(result).to.equal('admin')
+      })
+
+      it('should return admin when user is in any admin group', () => {
+        const config: OIDCConfig = {
+          ...baseConfig,
+          adminGroups: ['admins', 'sk-admin', 'superusers']
+        }
+        const result = mapGroupsToPermission(['sk-admin'], config)
+        expect(result).to.equal('admin')
+      })
+
+      it('should return defaultPermission when user not in admin groups', () => {
+        const config: OIDCConfig = {
+          ...baseConfig,
+          adminGroups: ['admins']
+        }
+        const result = mapGroupsToPermission(['users', 'viewers'], config)
+        expect(result).to.equal('readonly')
+      })
+    })
+
+    describe('with readwrite groups configured', () => {
+      it('should return readwrite when user is in readwrite group', () => {
+        const config: OIDCConfig = {
+          ...baseConfig,
+          readwriteGroups: ['users', 'editors']
+        }
+        const result = mapGroupsToPermission(['users'], config)
+        expect(result).to.equal('readwrite')
+      })
+
+      it('should return readwrite when user is in any readwrite group', () => {
+        const config: OIDCConfig = {
+          ...baseConfig,
+          readwriteGroups: ['users', 'editors', 'operators']
+        }
+        const result = mapGroupsToPermission(['viewers', 'operators'], config)
+        expect(result).to.equal('readwrite')
+      })
+
+      it('should return defaultPermission when user not in readwrite groups', () => {
+        const config: OIDCConfig = {
+          ...baseConfig,
+          readwriteGroups: ['editors']
+        }
+        const result = mapGroupsToPermission(['viewers'], config)
+        expect(result).to.equal('readonly')
+      })
+    })
+
+    describe('with both admin and readwrite groups configured', () => {
+      const config: OIDCConfig = {
+        ...baseConfig,
+        adminGroups: ['admins', 'sk-admin'],
+        readwriteGroups: ['users', 'operators']
+      }
+
+      it('should prioritize admin over readwrite', () => {
+        const result = mapGroupsToPermission(['users', 'admins'], config)
+        expect(result).to.equal('admin')
+      })
+
+      it('should return readwrite when in readwrite but not admin groups', () => {
+        const result = mapGroupsToPermission(['users', 'viewers'], config)
+        expect(result).to.equal('readwrite')
+      })
+
+      it('should return defaultPermission when in neither group', () => {
+        const result = mapGroupsToPermission(['viewers', 'guests'], config)
+        expect(result).to.equal('readonly')
+      })
+    })
+
+    describe('with custom defaultPermission', () => {
+      it('should use readwrite as default when configured', () => {
+        const config: OIDCConfig = {
+          ...baseConfig,
+          defaultPermission: 'readwrite'
+        }
+        const result = mapGroupsToPermission(['unknown-group'], config)
+        expect(result).to.equal('readwrite')
+      })
+
+      it('should use admin as default when configured', () => {
+        const config: OIDCConfig = {
+          ...baseConfig,
+          defaultPermission: 'admin'
+        }
+        const result = mapGroupsToPermission([], config)
+        expect(result).to.equal('admin')
+      })
+    })
+
+    describe('case sensitivity', () => {
+      it('should be case-sensitive by default', () => {
+        const config: OIDCConfig = {
+          ...baseConfig,
+          adminGroups: ['Admins']
+        }
+        const result = mapGroupsToPermission(['admins'], config)
+        expect(result).to.equal('readonly')
+      })
+
+      it('should match exactly with correct case', () => {
+        const config: OIDCConfig = {
+          ...baseConfig,
+          adminGroups: ['Admins']
+        }
+        const result = mapGroupsToPermission(['Admins'], config)
+        expect(result).to.equal('admin')
+      })
+    })
+
+    describe('edge cases', () => {
+      it('should handle empty admin groups array', () => {
+        const config: OIDCConfig = {
+          ...baseConfig,
+          adminGroups: [],
+          readwriteGroups: ['users']
+        }
+        const result = mapGroupsToPermission(['users'], config)
+        expect(result).to.equal('readwrite')
+      })
+
+      it('should handle empty readwrite groups array', () => {
+        const config: OIDCConfig = {
+          ...baseConfig,
+          adminGroups: ['admins'],
+          readwriteGroups: []
+        }
+        const result = mapGroupsToPermission(['admins'], config)
+        expect(result).to.equal('admin')
+      })
+
+      it('should handle groups with special characters', () => {
+        const config: OIDCConfig = {
+          ...baseConfig,
+          adminGroups: ['domain\\admins', 'org:admin-group']
+        }
+        const result = mapGroupsToPermission(['domain\\admins'], config)
+        expect(result).to.equal('admin')
+      })
+
+      it('should handle whitespace in group names', () => {
+        const config: OIDCConfig = {
+          ...baseConfig,
+          adminGroups: ['Signal K Admins']
+        }
+        const result = mapGroupsToPermission(['Signal K Admins'], config)
+        expect(result).to.equal('admin')
+      })
+    })
+  })
+})

--- a/test/oidc/pkce.test.ts
+++ b/test/oidc/pkce.test.ts
@@ -1,0 +1,73 @@
+import { expect } from 'chai'
+import {
+  generateCodeVerifier,
+  calculateCodeChallenge
+} from '../../src/oidc/pkce'
+
+describe('PKCE', () => {
+  describe('generateCodeVerifier', () => {
+    it('should generate 43-128 character string', () => {
+      const verifier = generateCodeVerifier()
+      expect(verifier.length).to.be.at.least(43)
+      expect(verifier.length).to.be.at.most(128)
+    })
+
+    it('should use only allowed characters [A-Za-z0-9-._~]', () => {
+      const verifier = generateCodeVerifier()
+      expect(verifier).to.match(/^[A-Za-z0-9\-._~]+$/)
+    })
+
+    it('should generate different values each call', () => {
+      const verifier1 = generateCodeVerifier()
+      const verifier2 = generateCodeVerifier()
+      expect(verifier1).to.not.equal(verifier2)
+    })
+
+    it('should be cryptographically random (high entropy)', () => {
+      // Generate multiple verifiers and check they're all different
+      const verifiers = new Set<string>()
+      for (let i = 0; i < 100; i++) {
+        verifiers.add(generateCodeVerifier())
+      }
+      // All 100 should be unique
+      expect(verifiers.size).to.equal(100)
+    })
+  })
+
+  describe('calculateCodeChallenge', () => {
+    it('should generate SHA256 base64url hash', () => {
+      // RFC 7636 test vector
+      const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk'
+      const challenge = calculateCodeChallenge(verifier)
+      expect(challenge).to.equal('E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM')
+    })
+
+    it('should match known test vectors', () => {
+      // Additional test vector
+      const verifier = 'test-verifier-123'
+      const challenge = calculateCodeChallenge(verifier)
+      // Should be deterministic
+      expect(challenge).to.equal(calculateCodeChallenge(verifier))
+    })
+
+    it('should generate URL-safe base64 (no padding)', () => {
+      const verifier = generateCodeVerifier()
+      const challenge = calculateCodeChallenge(verifier)
+      // No padding characters
+      expect(challenge).to.not.include('=')
+      // No non-URL-safe characters
+      expect(challenge).to.not.include('+')
+      expect(challenge).to.not.include('/')
+    })
+
+    it('should handle edge case verifiers', () => {
+      // Minimum length verifier (43 chars)
+      const minVerifier = 'a'.repeat(43)
+      expect(() => calculateCodeChallenge(minVerifier)).to.not.throw()
+
+      // Maximum length verifier (128 chars)
+      const maxVerifier = 'z'.repeat(128)
+      expect(() => calculateCodeChallenge(maxVerifier)).to.not.throw()
+    })
+  })
+})

--- a/test/oidc/settings-api.test.ts
+++ b/test/oidc/settings-api.test.ts
@@ -1,0 +1,416 @@
+/*
+ * Tests for OIDC Settings Admin API
+ * These tests verify the GET/PUT endpoints for OIDC configuration management
+ */
+
+import { expect } from 'chai'
+import { freeport } from '../ts-servertestutilities'
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const {
+  startServerP,
+  getAdminToken,
+  getReadOnlyToken,
+  getWriteToken
+} = require('../servertestutilities')
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+describe('OIDC Settings API', function () {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let server: any
+  let url: string
+  let port: number
+  let adminToken: string
+  let readOnlyToken: string
+  let writeToken: string
+
+  const validOIDCConfig = {
+    enabled: true,
+    issuer: 'https://auth.example.com',
+    clientId: 'signalk-client',
+    clientSecret: 'test-secret-123',
+    providerName: 'Test SSO',
+    defaultPermission: 'readonly',
+    autoCreateUsers: true,
+    autoLogin: false,
+    adminGroups: ['admins', 'sk-admins'],
+    readwriteGroups: ['users'],
+    groupsAttribute: 'groups',
+    scope: 'openid email profile groups'
+  }
+
+  before(async function () {
+    this.timeout(10000)
+    port = await freeport()
+    url = `http://0.0.0.0:${port}`
+
+    server = await startServerP(port, true, {
+      disableSchemaMetaDeltas: true
+    })
+
+    adminToken = await getAdminToken(server)
+    readOnlyToken = await getReadOnlyToken(server)
+    writeToken = await getWriteToken(server)
+  })
+
+  after(async function () {
+    await server.stop()
+  })
+
+  describe('GET /skServer/security/oidc', () => {
+    it('should require admin authentication', async () => {
+      const result = await fetch(`${url}/skServer/security/oidc`)
+      expect(result.status).to.equal(401)
+    })
+
+    it('should reject non-admin users', async () => {
+      const result = await fetch(`${url}/skServer/security/oidc`, {
+        headers: {
+          Cookie: `JAUTHENTICATION=${readOnlyToken}`
+        }
+      })
+      expect(result.status).to.equal(401)
+    })
+
+    it('should reject readwrite users', async () => {
+      const result = await fetch(`${url}/skServer/security/oidc`, {
+        headers: {
+          Cookie: `JAUTHENTICATION=${writeToken}`
+        }
+      })
+      expect(result.status).to.equal(401)
+    })
+
+    it('should return OIDC config for admin users', async () => {
+      const result = await fetch(`${url}/skServer/security/oidc`, {
+        headers: {
+          Cookie: `JAUTHENTICATION=${adminToken}`
+        }
+      })
+      expect(result.status).to.equal(200)
+
+      const json = (await result.json()) as Record<string, unknown>
+      expect(json).to.have.property('enabled')
+      expect(json).to.have.property('issuer')
+      expect(json).to.have.property('clientId')
+      expect(json).to.have.property('defaultPermission')
+    })
+
+    it('should not return the client secret in plain text', async () => {
+      const result = await fetch(`${url}/skServer/security/oidc`, {
+        headers: {
+          Cookie: `JAUTHENTICATION=${adminToken}`
+        }
+      })
+      expect(result.status).to.equal(200)
+
+      const json = (await result.json()) as Record<string, unknown>
+      // clientSecret should be redacted or indicate if set
+      expect(json.clientSecret).to.not.equal('test-secret-123')
+      // Should indicate if secret is set
+      expect(json).to.have.property('clientSecretSet')
+    })
+
+    it('should indicate which fields are set via environment variables', async () => {
+      const result = await fetch(`${url}/skServer/security/oidc`, {
+        headers: {
+          Cookie: `JAUTHENTICATION=${adminToken}`
+        }
+      })
+      expect(result.status).to.equal(200)
+
+      const json = (await result.json()) as Record<string, unknown>
+      // Should include envOverrides object indicating which fields come from env
+      expect(json).to.have.property('envOverrides')
+      expect(json.envOverrides).to.be.an('object')
+    })
+  })
+
+  describe('PUT /skServer/security/oidc', () => {
+    it('should require admin authentication', async () => {
+      const result = await fetch(`${url}/skServer/security/oidc`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(validOIDCConfig)
+      })
+      expect(result.status).to.equal(401)
+    })
+
+    it('should reject non-admin users', async () => {
+      const result = await fetch(`${url}/skServer/security/oidc`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: `JAUTHENTICATION=${readOnlyToken}`
+        },
+        body: JSON.stringify(validOIDCConfig)
+      })
+      expect(result.status).to.equal(401)
+    })
+
+    it('should accept valid OIDC configuration', async () => {
+      const result = await fetch(`${url}/skServer/security/oidc`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: `JAUTHENTICATION=${adminToken}`
+        },
+        body: JSON.stringify(validOIDCConfig)
+      })
+      expect(result.status).to.equal(200)
+    })
+
+    it('should persist configuration and return it on GET', async () => {
+      // First, save the config
+      const putResult = await fetch(`${url}/skServer/security/oidc`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: `JAUTHENTICATION=${adminToken}`
+        },
+        body: JSON.stringify(validOIDCConfig)
+      })
+      expect(putResult.status).to.equal(200)
+
+      // Then verify it's returned on GET
+      const getResult = await fetch(`${url}/skServer/security/oidc`, {
+        headers: {
+          Cookie: `JAUTHENTICATION=${adminToken}`
+        }
+      })
+      expect(getResult.status).to.equal(200)
+
+      const json = (await getResult.json()) as Record<string, unknown>
+      expect(json.enabled).to.equal(true)
+      expect(json.issuer).to.equal('https://auth.example.com')
+      expect(json.clientId).to.equal('signalk-client')
+      expect(json.providerName).to.equal('Test SSO')
+    })
+
+    it('should reject invalid issuer URL', async () => {
+      const invalidConfig = { ...validOIDCConfig, issuer: 'not-a-valid-url' }
+      const result = await fetch(`${url}/skServer/security/oidc`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: `JAUTHENTICATION=${adminToken}`
+        },
+        body: JSON.stringify(invalidConfig)
+      })
+      expect(result.status).to.equal(400)
+    })
+
+    it('should reject missing required fields when enabled', async () => {
+      const incompleteConfig = {
+        enabled: true,
+        issuer: 'https://auth.example.com'
+        // Missing clientId and clientSecret
+      }
+      const result = await fetch(`${url}/skServer/security/oidc`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: `JAUTHENTICATION=${adminToken}`
+        },
+        body: JSON.stringify(incompleteConfig)
+      })
+      expect(result.status).to.equal(400)
+    })
+
+    it('should accept disabled config without all required fields', async () => {
+      const disabledConfig = {
+        enabled: false,
+        issuer: '',
+        clientId: '',
+        clientSecret: ''
+      }
+      const result = await fetch(`${url}/skServer/security/oidc`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: `JAUTHENTICATION=${adminToken}`
+        },
+        body: JSON.stringify(disabledConfig)
+      })
+      expect(result.status).to.equal(200)
+    })
+
+    it('should preserve existing client secret if not provided in update', async () => {
+      // First, save config with secret
+      const putResult1 = await fetch(`${url}/skServer/security/oidc`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: `JAUTHENTICATION=${adminToken}`
+        },
+        body: JSON.stringify(validOIDCConfig)
+      })
+      expect(putResult1.status).to.equal(200)
+
+      // Update without providing clientSecret (or with empty string)
+      const updateWithoutSecret = {
+        ...validOIDCConfig,
+        clientSecret: '',
+        providerName: 'Updated SSO Name'
+      }
+      const putResult2 = await fetch(`${url}/skServer/security/oidc`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: `JAUTHENTICATION=${adminToken}`
+        },
+        body: JSON.stringify(updateWithoutSecret)
+      })
+      expect(putResult2.status).to.equal(200)
+
+      // Verify secret is still set
+      const getResult = await fetch(`${url}/skServer/security/oidc`, {
+        headers: {
+          Cookie: `JAUTHENTICATION=${adminToken}`
+        }
+      })
+      const json = (await getResult.json()) as Record<string, unknown>
+      expect(json.clientSecretSet).to.equal(true)
+      expect(json.providerName).to.equal('Updated SSO Name')
+    })
+
+    it('should reject invalid defaultPermission value', async () => {
+      const invalidConfig = {
+        ...validOIDCConfig,
+        defaultPermission: 'superadmin'
+      }
+      const result = await fetch(`${url}/skServer/security/oidc`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: `JAUTHENTICATION=${adminToken}`
+        },
+        body: JSON.stringify(invalidConfig)
+      })
+      expect(result.status).to.equal(400)
+    })
+
+    it('should accept adminGroups as comma-separated string', async () => {
+      const configWithStringGroups = {
+        ...validOIDCConfig,
+        adminGroups: 'admins, sk-admins, superusers'
+      }
+      const result = await fetch(`${url}/skServer/security/oidc`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: `JAUTHENTICATION=${adminToken}`
+        },
+        body: JSON.stringify(configWithStringGroups)
+      })
+      expect(result.status).to.equal(200)
+    })
+  })
+
+  describe('POST /skServer/security/oidc/test', () => {
+    it('should require admin authentication', async () => {
+      const result = await fetch(`${url}/skServer/security/oidc/test`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ issuer: 'https://auth.example.com' })
+      })
+      expect(result.status).to.equal(401)
+    })
+
+    it('should reject non-admin users', async () => {
+      const result = await fetch(`${url}/skServer/security/oidc/test`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: `JAUTHENTICATION=${readOnlyToken}`
+        },
+        body: JSON.stringify({ issuer: 'https://auth.example.com' })
+      })
+      expect(result.status).to.equal(401)
+    })
+
+    it('should return error for invalid issuer URL', async () => {
+      const result = await fetch(`${url}/skServer/security/oidc/test`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: `JAUTHENTICATION=${adminToken}`
+        },
+        body: JSON.stringify({ issuer: 'not-a-valid-url' })
+      })
+      expect(result.status).to.equal(400)
+    })
+
+    it('should return error for unreachable issuer', async () => {
+      const result = await fetch(`${url}/skServer/security/oidc/test`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: `JAUTHENTICATION=${adminToken}`
+        },
+        body: JSON.stringify({
+          issuer: 'https://nonexistent.invalid.example.com'
+        })
+      })
+
+      // Should return an error status indicating the connection failed
+      expect(result.status).to.be.oneOf([400, 502, 503])
+
+      const json = (await result.json()) as Record<string, unknown>
+      expect(json).to.have.property('error')
+    })
+
+    it('should return success for reachable OIDC provider with valid discovery', async () => {
+      // This test would require a mock OIDC server or a known public OIDC provider
+      // For now, we test the error case to ensure the endpoint exists
+      const result = await fetch(`${url}/skServer/security/oidc/test`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: `JAUTHENTICATION=${adminToken}`
+        },
+        body: JSON.stringify({ issuer: 'https://accounts.google.com' })
+      })
+
+      // Google is a known public OIDC provider
+      if (result.status === 200) {
+        const json = (await result.json()) as Record<string, unknown>
+        expect(json).to.have.property('success', true)
+        expect(json).to.have.property('issuer')
+        expect(json).to.have.property('authorization_endpoint')
+        expect(json).to.have.property('token_endpoint')
+      } else {
+        // If network is unavailable, test should not fail
+        console.log(
+          'Note: OIDC test endpoint returned non-200, possibly due to network'
+        )
+      }
+    })
+  })
+
+  describe('User list with OIDC indicator', () => {
+    it('should include OIDC information in user list', async () => {
+      const result = await fetch(`${url}/skServer/security/users`, {
+        headers: {
+          Cookie: `JAUTHENTICATION=${adminToken}`
+        }
+      })
+      expect(result.status).to.equal(200)
+
+      const users = (await result.json()) as Array<Record<string, unknown>>
+      expect(users).to.be.an('array')
+
+      // Each user should have an isOIDC field (or similar indicator)
+      users.forEach((user) => {
+        expect(user).to.have.property('userId')
+        expect(user).to.have.property('type')
+        // isOIDC should be present (false for local users)
+        expect(user).to.have.property('isOIDC')
+      })
+    })
+  })
+})

--- a/test/oidc/state.test.ts
+++ b/test/oidc/state.test.ts
@@ -1,0 +1,159 @@
+import { expect } from 'chai'
+import {
+  generateState,
+  generateNonce,
+  createAuthState,
+  validateState,
+  encryptState,
+  decryptState
+} from '../../src/oidc/state'
+import { OIDCError, STATE_MAX_AGE_MS } from '../../src/oidc/types'
+
+describe('State Management', () => {
+  const secretKey = '0'.repeat(64) // 256-bit hex key
+
+  describe('generateState', () => {
+    it('should generate cryptographically random string', () => {
+      const state1 = generateState()
+      const state2 = generateState()
+      expect(state1).to.not.equal(state2)
+    })
+
+    it('should be URL-safe', () => {
+      const state = generateState()
+      expect(state).to.match(/^[A-Za-z0-9\-_]+$/)
+    })
+
+    it('should be at least 32 characters', () => {
+      const state = generateState()
+      expect(state.length).to.be.at.least(32)
+    })
+  })
+
+  describe('generateNonce', () => {
+    it('should generate cryptographically random string', () => {
+      const nonce1 = generateNonce()
+      const nonce2 = generateNonce()
+      expect(nonce1).to.not.equal(nonce2)
+    })
+
+    it('should be URL-safe', () => {
+      const nonce = generateNonce()
+      expect(nonce).to.match(/^[A-Za-z0-9\-_]+$/)
+    })
+  })
+
+  describe('createAuthState', () => {
+    it('should create complete state object', () => {
+      const authState = createAuthState(
+        'https://example.com/callback',
+        '/admin'
+      )
+
+      expect(authState.state).to.be.a('string')
+      expect(authState.codeVerifier).to.be.a('string')
+      expect(authState.nonce).to.be.a('string')
+      expect(authState.redirectUri).to.equal('https://example.com/callback')
+      expect(authState.originalUrl).to.equal('/admin')
+      expect(authState.createdAt).to.be.a('number')
+    })
+
+    it('should include timestamp', () => {
+      const before = Date.now()
+      const authState = createAuthState('https://example.com/callback', '/')
+      const after = Date.now()
+
+      expect(authState.createdAt).to.be.at.least(before)
+      expect(authState.createdAt).to.be.at.most(after)
+    })
+
+    it('should generate unique state, verifier, nonce', () => {
+      const state1 = createAuthState('https://example.com/callback', '/')
+      const state2 = createAuthState('https://example.com/callback', '/')
+
+      expect(state1.state).to.not.equal(state2.state)
+      expect(state1.codeVerifier).to.not.equal(state2.codeVerifier)
+      expect(state1.nonce).to.not.equal(state2.nonce)
+    })
+  })
+
+  describe('validateState', () => {
+    it('should accept valid state', () => {
+      const authState = createAuthState('https://example.com/callback', '/')
+      expect(() => validateState(authState.state, authState)).to.not.throw()
+    })
+
+    it('should reject mismatched state', () => {
+      const authState = createAuthState('https://example.com/callback', '/')
+      expect(() => validateState('wrong-state', authState)).to.throw(
+        OIDCError,
+        /mismatch/
+      )
+    })
+
+    it('should reject expired state (>10 min)', () => {
+      const authState = createAuthState('https://example.com/callback', '/')
+      // Set createdAt to 11 minutes ago
+      authState.createdAt = Date.now() - STATE_MAX_AGE_MS - 60000
+
+      expect(() => validateState(authState.state, authState)).to.throw(
+        OIDCError,
+        /expired/
+      )
+    })
+
+    it('should accept state just under expiry limit', () => {
+      const authState = createAuthState('https://example.com/callback', '/')
+      // Set createdAt to 9 minutes ago (still valid)
+      authState.createdAt = Date.now() - STATE_MAX_AGE_MS + 60000
+
+      expect(() => validateState(authState.state, authState)).to.not.throw()
+    })
+  })
+
+  describe('encryptState/decryptState', () => {
+    it('should roundtrip state correctly', () => {
+      const authState = createAuthState(
+        'https://example.com/callback',
+        '/admin'
+      )
+      const encrypted = encryptState(authState, secretKey)
+      const decrypted = decryptState(encrypted, secretKey)
+
+      expect(decrypted.state).to.equal(authState.state)
+      expect(decrypted.codeVerifier).to.equal(authState.codeVerifier)
+      expect(decrypted.nonce).to.equal(authState.nonce)
+      expect(decrypted.redirectUri).to.equal(authState.redirectUri)
+      expect(decrypted.originalUrl).to.equal(authState.originalUrl)
+      expect(decrypted.createdAt).to.equal(authState.createdAt)
+    })
+
+    it('should fail on tampering', () => {
+      const authState = createAuthState('https://example.com/callback', '/')
+      const encrypted = encryptState(authState, secretKey)
+
+      // Tamper with encrypted data
+      const tamperedChars = encrypted.split('')
+      tamperedChars[20] = tamperedChars[20] === 'a' ? 'b' : 'a'
+      const tampered = tamperedChars.join('')
+
+      expect(() => decryptState(tampered, secretKey)).to.throw()
+    })
+
+    it('should fail with wrong key', () => {
+      const authState = createAuthState('https://example.com/callback', '/')
+      const encrypted = encryptState(authState, secretKey)
+      const wrongKey = '1'.repeat(64)
+
+      expect(() => decryptState(encrypted, wrongKey)).to.throw()
+    })
+
+    it('should produce different ciphertext each time (IV randomness)', () => {
+      const authState = createAuthState('https://example.com/callback', '/')
+      const encrypted1 = encryptState(authState, secretKey)
+      const encrypted2 = encryptState(authState, secretKey)
+
+      expect(encrypted1).to.not.equal(encrypted2)
+    })
+  })
+})

--- a/test/oidc/token-exchange.test.ts
+++ b/test/oidc/token-exchange.test.ts
@@ -19,7 +19,9 @@ describe('Token Exchange', () => {
     clientSecret: 'test-secret',
     scope: 'openid email profile',
     defaultPermission: 'readonly',
-    autoCreateUsers: true
+    autoCreateUsers: true,
+    providerName: 'SSO Login',
+    autoLogin: false
   }
 
   const metadata: OIDCProviderMetadata = {

--- a/test/oidc/token-exchange.test.ts
+++ b/test/oidc/token-exchange.test.ts
@@ -1,0 +1,219 @@
+import { expect } from 'chai'
+import {
+  exchangeAuthorizationCode,
+  setFetchFunction as setTokenFetch,
+  resetFetchFunction as resetTokenFetch
+} from '../../src/oidc/token-exchange'
+import {
+  OIDCConfig,
+  OIDCAuthState,
+  OIDCProviderMetadata,
+  OIDCError
+} from '../../src/oidc/types'
+
+describe('Token Exchange', () => {
+  const config: OIDCConfig = {
+    enabled: true,
+    issuer: 'https://auth.example.com',
+    clientId: 'signalk-server',
+    clientSecret: 'test-secret',
+    scope: 'openid email profile',
+    defaultPermission: 'readonly',
+    autoCreateUsers: true
+  }
+
+  const metadata: OIDCProviderMetadata = {
+    issuer: 'https://auth.example.com',
+    authorization_endpoint: 'https://auth.example.com/authorize',
+    token_endpoint: 'https://auth.example.com/token',
+    jwks_uri: 'https://auth.example.com/.well-known/jwks.json',
+    response_types_supported: ['code'],
+    code_challenge_methods_supported: ['S256']
+  }
+
+  const authState: OIDCAuthState = {
+    state: 'test-state-value',
+    codeVerifier: 'test-code-verifier-12345678901234567890',
+    nonce: 'test-nonce-value',
+    redirectUri: 'https://signalk.local:3000/signalk/v1/auth/oidc/callback',
+    originalUrl: '/admin',
+    createdAt: Date.now()
+  }
+
+  const validTokenResponse = {
+    access_token: 'access-token-value',
+    id_token: 'id-token-value',
+    token_type: 'Bearer',
+    expires_in: 3600
+  }
+
+  afterEach(() => {
+    resetTokenFetch()
+  })
+
+  describe('exchangeAuthorizationCode', () => {
+    it('should send correct POST request to token endpoint', async () => {
+      let capturedUrl: string | undefined
+      let capturedInit: RequestInit | undefined
+
+      const mockFetch = async (
+        url: string | URL | Request,
+        init?: RequestInit
+      ): Promise<Response> => {
+        capturedUrl = url.toString()
+        capturedInit = init
+        return new Response(JSON.stringify(validTokenResponse), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+      }
+      setTokenFetch(mockFetch)
+
+      await exchangeAuthorizationCode(
+        'auth-code-123',
+        config,
+        metadata,
+        authState
+      )
+
+      expect(capturedUrl).to.equal('https://auth.example.com/token')
+      expect(capturedInit?.method).to.equal('POST')
+      expect(capturedInit?.headers).to.include({
+        'Content-Type': 'application/x-www-form-urlencoded'
+      })
+    })
+
+    it('should include code_verifier for PKCE', async () => {
+      let capturedBody: string | undefined
+
+      const mockFetch = async (
+        _url: string | URL | Request,
+        init?: RequestInit
+      ): Promise<Response> => {
+        capturedBody = init?.body as string
+        return new Response(JSON.stringify(validTokenResponse), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+      }
+      setTokenFetch(mockFetch)
+
+      await exchangeAuthorizationCode(
+        'auth-code-123',
+        config,
+        metadata,
+        authState
+      )
+
+      const params = new URLSearchParams(capturedBody)
+      expect(params.get('code_verifier')).to.equal(authState.codeVerifier)
+      expect(params.get('code')).to.equal('auth-code-123')
+      expect(params.get('grant_type')).to.equal('authorization_code')
+      expect(params.get('client_id')).to.equal('signalk-server')
+      expect(params.get('client_secret')).to.equal('test-secret')
+      expect(params.get('redirect_uri')).to.equal(authState.redirectUri)
+    })
+
+    it('should handle successful response', async () => {
+      const mockFetch = async (): Promise<Response> => {
+        return new Response(JSON.stringify(validTokenResponse), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+      }
+      setTokenFetch(mockFetch)
+
+      const tokens = await exchangeAuthorizationCode(
+        'auth-code-123',
+        config,
+        metadata,
+        authState
+      )
+
+      expect(tokens.accessToken).to.equal('access-token-value')
+      expect(tokens.idToken).to.equal('id-token-value')
+      expect(tokens.tokenType).to.equal('Bearer')
+      expect(tokens.expiresIn).to.equal(3600)
+    })
+
+    it('should handle error response', async () => {
+      const mockFetch = async (): Promise<Response> => {
+        return new Response(
+          JSON.stringify({
+            error: 'invalid_grant',
+            error_description: 'Authorization code expired'
+          }),
+          {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' }
+          }
+        )
+      }
+      setTokenFetch(mockFetch)
+
+      try {
+        await exchangeAuthorizationCode(
+          'auth-code-123',
+          config,
+          metadata,
+          authState
+        )
+        expect.fail('Should have thrown')
+      } catch (err) {
+        expect(err).to.be.instanceOf(OIDCError)
+        expect((err as OIDCError).code).to.equal('TOKEN_EXCHANGE_FAILED')
+        expect((err as OIDCError).message).to.include('invalid_grant')
+      }
+    })
+
+    it('should handle network errors', async () => {
+      const mockFetch = async (): Promise<Response> => {
+        throw new Error('Network error')
+      }
+      setTokenFetch(mockFetch)
+
+      try {
+        await exchangeAuthorizationCode(
+          'auth-code-123',
+          config,
+          metadata,
+          authState
+        )
+        expect.fail('Should have thrown')
+      } catch (err) {
+        expect(err).to.be.instanceOf(OIDCError)
+        expect((err as OIDCError).code).to.equal('TOKEN_EXCHANGE_FAILED')
+      }
+    })
+
+    it('should validate response structure', async () => {
+      const mockFetch = async (): Promise<Response> => {
+        return new Response(
+          JSON.stringify({
+            // Missing access_token
+            id_token: 'id-token-value',
+            token_type: 'Bearer'
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' }
+          }
+        )
+      }
+      setTokenFetch(mockFetch)
+
+      try {
+        await exchangeAuthorizationCode(
+          'auth-code-123',
+          config,
+          metadata,
+          authState
+        )
+        expect.fail('Should have thrown')
+      } catch (err) {
+        expect(err).to.be.instanceOf(OIDCError)
+        expect((err as OIDCError).code).to.equal('TOKEN_EXCHANGE_FAILED')
+      }
+    })
+  })
+})

--- a/test/oidc/user-info.test.ts
+++ b/test/oidc/user-info.test.ts
@@ -1,0 +1,108 @@
+import { expect } from 'chai'
+import { extractUserInfo, decodeIdToken } from '../../src/oidc/user-info'
+import { OIDCError } from '../../src/oidc/types'
+
+describe('User Info', () => {
+  // Helper to create a JWT (unsigned, for testing claims extraction only)
+  function createTestJwt(payload: object): string {
+    const header = { alg: 'none', typ: 'JWT' }
+    const encodedHeader = Buffer.from(JSON.stringify(header)).toString(
+      'base64url'
+    )
+    const encodedPayload = Buffer.from(JSON.stringify(payload)).toString(
+      'base64url'
+    )
+    return `${encodedHeader}.${encodedPayload}.`
+  }
+
+  describe('decodeIdToken', () => {
+    it('should decode a valid JWT payload', () => {
+      const payload = {
+        sub: 'user123',
+        email: 'user@example.com',
+        name: 'Test User'
+      }
+      const token = createTestJwt(payload)
+      const decoded = decodeIdToken(token)
+
+      expect(decoded.sub).to.equal('user123')
+      expect(decoded.email).to.equal('user@example.com')
+      expect(decoded.name).to.equal('Test User')
+    })
+
+    it('should throw on invalid token format', () => {
+      expect(() => decodeIdToken('not-a-jwt')).to.throw(OIDCError, /Invalid/)
+      expect(() => decodeIdToken('only.two')).to.throw(OIDCError, /Invalid/)
+    })
+
+    it('should throw on invalid base64', () => {
+      expect(() => decodeIdToken('xxx.!!!invalid!!!.zzz')).to.throw(OIDCError)
+    })
+  })
+
+  describe('extractUserInfo', () => {
+    it('should extract sub from ID token', () => {
+      const token = createTestJwt({ sub: 'unique-user-id-123' })
+      const userInfo = extractUserInfo(token)
+
+      expect(userInfo.sub).to.equal('unique-user-id-123')
+    })
+
+    it('should extract email if present', () => {
+      const token = createTestJwt({
+        sub: 'user123',
+        email: 'user@example.com'
+      })
+      const userInfo = extractUserInfo(token)
+
+      expect(userInfo.email).to.equal('user@example.com')
+    })
+
+    it('should extract name/preferred_username', () => {
+      const tokenWithName = createTestJwt({
+        sub: 'user123',
+        name: 'John Doe'
+      })
+      const userInfo1 = extractUserInfo(tokenWithName)
+      expect(userInfo1.name).to.equal('John Doe')
+
+      const tokenWithPreferredUsername = createTestJwt({
+        sub: 'user123',
+        preferred_username: 'johndoe'
+      })
+      const userInfo2 = extractUserInfo(tokenWithPreferredUsername)
+      expect(userInfo2.preferredUsername).to.equal('johndoe')
+    })
+
+    it('should extract groups if present', () => {
+      const token = createTestJwt({
+        sub: 'user123',
+        groups: ['admin', 'users', 'signalk-readwrite']
+      })
+      const userInfo = extractUserInfo(token)
+
+      expect(userInfo.groups).to.deep.equal([
+        'admin',
+        'users',
+        'signalk-readwrite'
+      ])
+    })
+
+    it('should handle missing optional claims', () => {
+      const token = createTestJwt({ sub: 'user123' })
+      const userInfo = extractUserInfo(token)
+
+      expect(userInfo.sub).to.equal('user123')
+      expect(userInfo.email).to.equal(undefined)
+      expect(userInfo.name).to.equal(undefined)
+      expect(userInfo.preferredUsername).to.equal(undefined)
+      expect(userInfo.groups).to.equal(undefined)
+    })
+
+    it('should throw if sub is missing', () => {
+      const token = createTestJwt({ email: 'user@example.com' })
+
+      expect(() => extractUserInfo(token)).to.throw(OIDCError, /sub/)
+    })
+  })
+})

--- a/typedoc.json
+++ b/typedoc.json
@@ -71,7 +71,8 @@
     "json",
     "javascript",
     "typescript",
-    "nginx"
+    "nginx",
+    "yaml"
   ],
   "cacheBust": true
 }


### PR DESCRIPTION
Saving OIDC settings was failing in React, apparently because
there is no Spinner in reactstrap version that
the admin ui is using.