### PR TITLE
Add EXTERNALSSL env var for proxy-terminated TLS

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -41,6 +41,7 @@ const packageJson = require('../../' + 'package.json')
 export interface Config {
   getExternalHostname: () => string
   getExternalPort: () => number
+  isExternalSsl: () => boolean
   port: number
   appPath: string
   configPath: string
@@ -67,6 +68,7 @@ export interface Config {
     landingPage?: string
     proxy_host?: string
     proxy_port?: number
+    proxy_ssl?: boolean
     hostname?: string
     pruneContextsMinutes?: number
     mdns?: boolean
@@ -97,6 +99,7 @@ export function load(app: ConfigApp) {
 
   config.getExternalHostname = getExternalHostname.bind(config, config)
   config.getExternalPort = getExternalPort.bind(config, app)
+  config.isExternalSsl = isExternalSsl.bind(null, config)
 
   config.appPath = config.appPath || path.normalize(__dirname + '/../../')
   debug('appPath:' + config.appPath)
@@ -445,6 +448,16 @@ function getSettingsFilename(app: ConfigApp) {
 
   const settingsFile = app.argv.s || 'settings.json'
   return path.join(app.config.configPath, settingsFile)
+}
+
+function isExternalSsl(config: Config): boolean {
+  if (process.env.EXTERNALSSL) {
+    return (
+      process.env.EXTERNALSSL === '1' ||
+      process.env.EXTERNALSSL.toLowerCase() === 'true'
+    )
+  }
+  return !!config.settings.proxy_ssl
 }
 
 function getExternalHostname(config: Config) {

--- a/src/interfaces/mfd_webapp.ts
+++ b/src/interfaces/mfd_webapp.ts
@@ -17,7 +17,7 @@ module.exports = (theApp: any) => {
   return {
     start() {
       const port = getExternalPort(theApp)
-      const protocol = theApp.config.settings.ssl ? 'https' : 'http'
+      const protocol = (theApp.config.settings.ssl || theApp.config.isExternalSsl()) ? 'https' : 'http'
       const publishToNavico = getPublishToNavico(protocol, port)
       setInterval(() => publishToNavico(), 10 * 1000)
     }

--- a/src/interfaces/rest.js
+++ b/src/interfaces/rest.js
@@ -178,7 +178,7 @@ module.exports = function (app) {
     },
 
     mdns: {
-      name: app.config.settings.ssl ? '_signalk-https' : '_signalk-http',
+      name: (app.config.settings.ssl || app.config.isExternalSsl()) ? '_signalk-https' : '_signalk-http',
       type: 'tcp',
       port: ports.getExternalPort(app)
     }

--- a/src/interfaces/ws.js
+++ b/src/interfaces/ws.js
@@ -39,7 +39,7 @@ module.exports = function (app) {
   const pathSources = {}
 
   api.mdns = {
-    name: app.config.settings.ssl ? '_signalk-wss' : '_signalk-ws',
+    name: (app.config.settings.ssl || app.config.isExternalSsl()) ? '_signalk-wss' : '_signalk-ws',
     type: 'tcp',
     port: ports.getExternalPort(app)
   }

--- a/src/mdns.js
+++ b/src/mdns.js
@@ -57,7 +57,7 @@ module.exports = function mdnsResponder(app) {
 
   const types = []
   types.push({
-    type: app.config.settings.ssl ? mdns.tcp('https') : mdns.tcp('http'),
+    type: (app.config.settings.ssl || app.config.isExternalSsl()) ? mdns.tcp('https') : mdns.tcp('http'),
     port: ports.getExternalPort(app)
   })
 


### PR DESCRIPTION
## Summary

- Adds `EXTERNALSSL` env var (and `proxy_ssl` settings field) to indicate external TLS termination by a reverse proxy
- Updates mDNS advertisement in `ws.js`, `rest.js`, `mdns.js`, and `mfd_webapp.ts` to use `_signalk-wss`/`_signalk-https`/`https` when external SSL is active
- Follows the existing pattern of `EXTERNALHOST` and `EXTERNALPORT`

## Context

When Signal K runs behind a TLS-terminating reverse proxy (e.g. Traefik, nginx), `settings.ssl` is `false` because Signal K itself serves plain HTTP. This causes mDNS to advertise `_signalk-ws._tcp` instead of `_signalk-wss._tcp`, and clients like SensESP connect with plain HTTP to a port that expects HTTPS, failing silently.

The REST discovery endpoint (`rest.js:141-148`) already handles this correctly via `x-forwarded-proto`. This PR extends the same awareness to mDNS and MFD discovery.

**Intent: submit upstream to SignalK/signalk-server once reviewed.**

## Usage

```bash
# Environment variable (takes precedence)
EXTERNALSSL=1  # or EXTERNALSSL=true

# Or in settings.json
{ "proxy_ssl": true }
```

## Test plan

Tested on HaLOS (Traefik TLS termination on port 4430):

- [x] With `EXTERNALSSL=1`: `dns-sd -B _signalk-wss._tcp` shows the server; `_signalk-ws._tcp` does not
- [ ] Without `EXTERNALSSL`: behavior unchanged, advertises `_signalk-ws._tcp`
- [ ] `settings.ssl: true` (direct TLS) still works as before
- [x] SensESP discovers server via `_signalk-wss` mDNS and connects over WSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)